### PR TITLE
add legal pages

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -137,6 +137,8 @@ else:
 JOBIRL_API_KEY = env("JOBIRL_API_KEY", default="")
 JOBIRL_URL = env("JOBIRL_URL", default="")
 
+SITE_URL = env("HOST", default="https://localhost:8000")
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/6.0/topics/i18n/

--- a/techpourtoutes/templates/coallition/mentor_landing.html
+++ b/techpourtoutes/templates/coallition/mentor_landing.html
@@ -6,16 +6,18 @@
     </div>
 
     <c-components.card title="Aidez une jeune à construire son projet professionnel">
-        Rejoignez la communauté TechPourToutes de mentors pour avoir un impact concret sur l'avenir de vos mentorées.
+        <c-components.text>
+            Rejoignez la communauté TechPourToutes de mentors pour avoir un impact concret sur l'avenir de vos mentorées.
 
-        Au cours de ces 6 mois de mentorat, vous apprendez à vous connaître et vous aurez l'occasion de les aider à affiner leur projet d'étude ou de carrière, à gagner en confiance et à accéder à de nouvelles opportunités.
+            Au cours de ces 6 mois de mentorat, vous apprendez à vous connaître et vous aurez l'occasion de les aider à affiner leur projet d'étude ou de carrière, à gagner en confiance et à accéder à de nouvelles opportunités.
+        </c-components.text>
     </c-components.card>
 
     <div class="flex justify-center w-full md:hidden">
         <c-components.button href="#mentor-card" label="Je deviens mentor" />
     </div>
 
-    <c-components.card variant="custom" title="Les 4 étapes clés du mentorat en ligne" nobg=True>
+    <c-components.card title="Les 4 étapes clés du mentorat en ligne" nobg=True>
         <ul class="steps steps-vertical">
         <li class="step step-secondary text-left">JobIrl prend contact avec vous et vous forme</li>
         <li class="step step-secondary text-left">Vous êtes mise en relation avec une mentorée</li>
@@ -25,9 +27,11 @@
     </c-components.card>
 
     <c-components.card title="On vous accompagne à toutes les étapes">
-        Sur la plateforme TechPourToutes, vous retrouverez de nombreuses informations sur les formations, les stages, des événements, etc.
+        <c-components.text>
+            Sur la plateforme TechPourToutes, vous retrouverez de nombreuses informations sur les formations, les stages, des événements, etc.
 
-        Les équipes de JobIrl, membre du consortium TechPourToutes vous apportent tout le soutien dont vous avez besoin au fur et à mesure de vos échanges.
+            Les équipes de JobIrl, membre du consortium TechPourToutes vous apportent tout le soutien dont vous avez besoin au fur et à mesure de vos échanges.
+        </c-components.text>
     </c-components.card>
 
     <c-slot name="right">

--- a/techpourtoutes/templates/coallition/mentor_success.html
+++ b/techpourtoutes/templates/coallition/mentor_success.html
@@ -2,8 +2,10 @@
     <c-components.title icon-name="mentorer-bold" title="Mentorer" />
 
     <c-components.card title="Merci pour votre engagement !">
-        Votre inscription en tant que mentor TechPourToutes a bien été prise en compte.
+        <c-components.text>
+            Votre inscription en tant que mentor TechPourToutes a bien été prise en compte.
 
-        L'équipe JobIrl va vous contacter prochainement pour vous accompagner dans vos premiers pas.
+            L'équipe JobIrl va vous contacter prochainement pour vous accompagner dans vos premiers pas.
+        </c-components.text>
     </c-components.card>
 </c-layout.base>

--- a/techpourtoutes/templates/legals/accessibilite.html
+++ b/techpourtoutes/templates/legals/accessibilite.html
@@ -1,0 +1,38 @@
+<c-layout.base>
+    <c-components.title title="Accessibilité" />
+
+    <c-components.card title="Conformité au RGGA 4.1">
+        <c-components.title variant="intertitre" title="État de conformité" />
+
+        <c-components.text>
+            La Fondation Inria s'engage à rendre accessible son site web conformément à l'article 47 de la loi n°2005–102 du 11 février 2005.
+
+            À cette fin, la Fondation Inria met en œuvre la stratégie décrite au sein de son <u><a href="{% url "schema_pluriannuel" %}">Schéma pluriannuel de mise en accessibilité 2026 - 2028</a></u>
+
+            Cette déclaration d'accessibilité s'applique au site <a href="{{ site_url }}">techpourtoutes.io</a>
+
+            À l'heure actuelle, le site <a href="{{ site_url }}">techpourtoutes.io</a> n'a pas encore été audité car il est toujours en cours de construction. Il est de facto considéré comme non conforme.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Retour d’information et contact">
+        <c-components.text>
+            Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de l’application pour être orientée vers une alternative accessible ou obtenir le contenu sous une autre forme : <a href="mailto:accessibilite@techpourtoutes.io">accessibilite@techpourtoutes.io</a>
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Voie de recours">
+        <c-components.text>
+            Cette procédure est à utiliser dans le cas suivant&nbsp;: Vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+
+            Écrire un message au <u><a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a></u>
+
+            Contacter le délégué du <u><a href="https://www.defenseurdesdroits.fr/saisir/delegues">Défenseur des droits dans votre région</a></u>
+
+            Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :
+            Défenseur des droits
+            Libre réponse 71120
+            75342 Paris CEDEX 07
+        </c-components.text>
+    </c-components.card>
+</c-layout.base>

--- a/techpourtoutes/templates/legals/conditions_generales.html
+++ b/techpourtoutes/templates/legals/conditions_generales.html
@@ -1,0 +1,183 @@
+<c-layout.base>
+    <c-components.title title="Conditions générales d'utilisation - Coalition" />
+
+    <p class="max-w-2xl">Version en date du 27 avril 2026</p>
+
+    <c-components.card title="Introduction">
+        <c-components.text>
+            <strong>1.</strong> Toute utilisation de notre site internet <u><a href="{{ site_url }}/coalition">techpourtoutes.io/coalition</a></u> (le «&nbsp;Site Coalition&nbsp;»), y compris l’ensemble des services, ressources, médias et données disponibles ou accessibles via le Site (chacun désigne un «&nbsp;Service&nbsp;», et collectivement les «&nbsp;Services&nbsp;», et ensemble les Services et le Site, la «&nbsp;Plateforme&nbsp;»), est régie par les présentes Conditions Générales d’Utilisation (les «&nbsp;CGU&nbsp;»).
+
+            <strong>2.</strong> Les présentes CGU régissent l’accès et l’utilisation du Site et des Services par : (a) toute personne physique ou morale qui accède, consulte ou utilise de quelque manière que ce soit le Site ou les Services («&nbsp;Utilisatrice&nbsp;» ou "Utilisateur"), et/ou (b) les personnes physiques qui créent un compte et utilisent la Plateforme dans le but de rejoindre la coalition et de s'engager auprès de TechPourToutes (les «&nbsp;Bénévoles&nbsp;»). Lorsque les présentes CGU font référence à «&nbsp;vous&nbsp;», cette référence s’applique à l’ensemble des Utilisatrices, Utilisateurs et Bénévoles, selon le cas.
+
+            <strong>3.</strong> La Plateforme est détenue et exploitée par la Fondation Inria («&nbsp;nous&nbsp;» ou «&nbsp;notre&nbsp;»), Fondation partenariale d’Inria, dont le siège social est situé au Domaine de Voluceau Rocquencourt ; BP 105 ; 78153 LE CHESNAY Cedex. La société est représentée par Bruno Sportisse, Président de la Fondation Inria.En acceptant les présentes CGU, vous concluez un contrat avec la Fondation Inria.
+
+            <strong>4.</strong> En créant un Compte (tel que défini ci-après), ou en visitant, accédant, consultant ou utilisant la Plateforme de quelque manière que ce soit, vous acceptez de vous conformer aux présentes CGU. Si vous n’acceptez pas les présentes CGU, vous devez immédiatement cesser d’utiliser la Plateforme et/ou vous abstenir de créer un Compte.
+
+            <strong>5.</strong> Vous pouvez nous contacter à tout moment en nous écrivant à l’adresse de notre siège social mentionnée ci-dessus ou par mail à <u><a href="mailto:bonjour@techpourtoutes.io">bonjour@techpourtoutes.io</a></u>. Nous mettrons tout en œuvre pour répondre à vos préoccupations. Si vous considérez que vos questions ou préoccupations n’ont pas été traitées de façon complète, nous vous invitons à nous en informer afin qu’une investigation approfondie puisse être menée.
+
+            <strong>6.</strong> Si vous avez déjà conclu un contrat avec la Fondation Inria pour vous bénéficier des services du programme TechPourToutes, des conditions générales distinctes s’appliquent à l’utilisation de notre Plateforme. Ces conditions sont disponibles dans les Conditions générales d'utilisation - Programme.        </c-components.text>
+    </c-components.card>
+    <c-components.card title="PARTIE A - QUI SOMMES-NOUS / OBLIGATIONS">
+        <c-components.title title="7. Que faisons-nous ?" variant="intertitre" />
+        <c-components.text>
+            Nous mettons à disposition une plateforme en ligne permettant aux Bénévoles d'accéder à tes informations et à s'engager auprès de TechPourToutes pour participer à la féminisation des filières techniques du numérique. Pour cela, nous mettons en relation les Bénévoles avec des Bénéficiaires, définies comme toute lycéenne ou étudiante entre 15 et 25 ans souhaitant s'identifier et être mise en relation avec des Bénévoles (ci-après les «&nbsp;Bénéficiaires&nbsp;»).
+
+            Nous proposons également des ressources et d'autres services aux Bénéficiaires.
+        </c-components.text>
+
+        <c-components.title title="8. Modifications des présentes Conditions Générales d’Utilisation" variant="intertitre" />
+        <c-components.text>
+            Chaque fois que vous souhaitez utiliser notre Plateforme, nous vous invitons à consulter les présentes CGU afin de vous assurer que vous êtes informés des conditions applicables à ce moment là. Vous pouvez consulter la version en vigueur des CGU à tout moment sur cette page.
+
+            Nous nous réservons le droit de modifier les CGU à tout moment, à notre seule discrétion. Lorsque des modifications sont apportées, la Fondation Inria mettra une nouvelle version des CGU à disposition sur le Site. Nous mettrons également à jour la date de «&nbsp;Dernière mise à jour&nbsp;» figurant en tête des CGU. Si nous apportons des modifications substantielles, et que vous disposez d'un Compte (tel que défini à l’article 11 ci-après), nous vous enverrons également un e-mail à la dernière adresse électronique que vous nous avez communiquée dans le cadre des présentes CGU.
+
+            Toute modification des CGU prendra effet immédiatement pour les nouveaux utilisatrices ou utilisateurs du Site et/ou des Services, et prendra effet trente (30) jours après la publication d’un avis de modification sur le Site pour les titulaires de Compte existants, étant précisé que toute modification substantielle prendra effet pour les titulaires d’un Compte auprès de nous à l’expiration du délai le plus court entre leur acceptation formelle des CGU, trente (30) jours suivant la publication d’un avis de modification sur le Site ou trente (30) jours suivant l’envoi d’un avis de modification par e-mail aux dites personnes.
+
+            La Fondation Inria pourra vous demander d’exprimer votre consentement aux CGU mises à jour selon les modalités précisées avant que vous puissiez continuer à utiliser le Site et/ou les Services. Si vous n’acceptez pas les modifications après en avoir été notifié ou notifiée, vous devez cesser d’utiliser le Site et/ou les Services. À défaut, votre utilisation du Site après l’expiration du délai de notification vaudra acceptation continue des CGU, telles que modifiées de temps à autre. Chaque fois que vous souhaitez utiliser notre Site, nous vous invitons à consulter les présentes CGU afin de vous assurer que vous comprenez les conditions applicables à ce moment-là. Vous pouvez consulter la version en vigueur des CGU à tout moment sur cette page.
+        </c-components.text>
+
+        <c-components.title title="9. Modifications du Site ou des Services" variant="intertitre" />
+        <c-components.text>
+            Nous sommes susceptibles de mettre à jour et de modifier notre Site et/ou nos Services. Nous ne garantissons pas que notre Site, nos Services ou tout Contenu qui y figure seront toujours disponibles de manière ininterrompue ou sans erreur, et nous nous réservons le droit de retirer, suspendre ou modifier les Services ou fonctionnalités que nous proposons sur le Site, sans préavis et pour quelque raison que ce soit. Nous nous efforcerons de vous informer dans un délai raisonnable de toute modification substantielle, suspension ou retrait des produits, Services ou fonctionnalités.
+        </c-components.text>
+
+        <c-components.title title="10. Vos obligations" variant="intertitre" />
+        <c-components.text>
+            Vous êtes responsable de la configuration de vos systèmes informatiques pour accéder à nos Services et à notre Site. Nous vous recommandons d’utiliser votre propre logiciel de protection contre les virus.
+
+            Vous acceptez de vous conformer à l’ensemble des lois, règles et réglementations qui vous sont applicables dans le cadre de l’utilisation du Site et de nos Services.
+
+            En conséquence, lors de l’utilisation du Site et de nos Services, il vous est interdit de :
+        </c-components.text>
+
+        <c-components.list>
+            Concéder sous licence, vendre, louer, céder à bail, transférer, céder, reproduire, distribuer, héberger ou exploiter commercialement de toute autre manière la Plateforme ou toute partie de celle-ci, y compris le Site ;
+
+            Sauf disposition expresse contraire aux présentes, copier, reproduire, distribuer, republier, télécharger, afficher ou publier sous quelque forme ou par quelque moyen que ce soit toute partie de la Plateforme ;
+
+            Utiliser abusivement le Site ou les Services en introduisant sciemment des virus, chevaux de Troie, vers, bombes logiques ou tout autre élément malveillant ou technologiquement nuisible ;
+
+            Tenter d’accéder sans autorisation aux Services, au Site, au serveur sur lequel le Site ou les Services sont hébergés, ou à tout serveur, ordinateur ou base de données connecté au Site ou aux Services ;
+
+            Attaquer notre Plateforme par le biais d’une attaque par déni de service (DoS) ou d’une attaque par déni de service distribué (DDoS) ;
+
+            Développer, soutenir ou utiliser tout logiciel, dispositif, script, robot ou tout autre moyen ou procédé (y compris, sans s’y limiter, les robots d’indexation, les extensions et modules de navigateur, ou toute autre technologie) pour procéder à une extraction automatisée de données («&nbsp;scraping&nbsp;») ou copier ou télécharger de toute autre manière notre Site, nos Contenus ou nos Services, y compris les profils d’entreprise ainsi que toutes les autres données disponibles sur le Site (étant précisé que nous accordons aux opérateurs de moteurs de recherche publics une autorisation révocable d’utiliser des robots d’indexation pour copier des éléments du Site dans le seul but et dans la seule mesure nécessaire à la création d’index de recherche accessibles au public, à l’exclusion de tout cache ou archive de ces éléments) ;
+
+            Utiliser des balises méta ou tout autre «&nbsp;texte caché&nbsp;» faisant usage du nom ou des marques de TechPourToutes sauf autorisation spéciale ;
+
+            Supprimer ou détruire tout avis de droit d’auteur ou toute autre mention de propriété figurant sur ou dans la Plateforme ;
+
+            Porter atteinte aux droits de propriété intellectuelle ou autres droits de la Fondation Inria, notamment, sans s’y limiter : (i) en copiant ou en distribuant les Contenus, y compris les photos et vidéos disponibles sur les Services ou le Site; (ii) en copiant ou en distribuant nos articles et autres contenus médias; (iii) en utilisant les termes «&nbsp;Fondation Inria&nbsp;» et/ou «&nbsp;TechPourToutes&nbsp;»;
+
+            Procéder à une ingénierie inverse, décompiler, désassembler, déchiffrer, modifier, traduire, adapter, fusionner, créer des œuvres dérivées de, ou tenter d’obtenir de quelque manière que ce soit le code source de la Plateforme ou de toute technologie connexe, sauf dans la mesure où ces restrictions seraient expressément prohibées par la loi applicable ;
+
+            Utiliser la technique du «&nbsp;framing&nbsp;» (cadrage) ou du «&nbsp;mirroring&nbsp;» (site miroir) pour encadrer toute marque, logo ou autre Contenu de la Plateforme (y compris des images, textes, mises en page ou formulaires) ou, de manière générale, simuler l’apparence ou le fonctionnement des Services ou du Site ; et/ou
+
+            Utiliser le Site et/ou les Services de quelque manière que ce soit qui : (i) cause ou soit susceptible de causer des dommages aux Services ou au Site, ou interfère avec l’utilisation ou la jouissance des Services ou du Site par toute autre personne ; (ii) soit préjudiciable, contraire à la loi, illégale, abusive, harcelante, menaçante, ou autrement répréhensible, ou constitue une violation de toute loi, réglementation ou ordonnance gouvernementale applicable.
+
+            Vous êtes également responsable de vous assurer que toutes les personnes qui accèdent à notre Site ou à nos Services via votre connexion internet ont pris connaissance des présentes CGU (y compris les politiques et conditions annexes) et les respectent.
+
+            En cas de violation des restrictions ou obligations susmentionnées, nous nous réservons le droit de suspendre ou de résilier immédiatement votre droit d’utilisation de la Plateforme.
+        </c-components.list>
+    </c-components.card>
+
+    <c-components.card title="PARTIE B - CRÉATION DE COMPTE ET DESCRIPTION DE NOS SERVICES">
+        <c-components.title title="11. Inscription : Création d’un Compte Bénévole" variant="intertitre" />
+        <c-components.text>
+        Vous devrez vous inscrire et créer un compte (le «&nbsp;Compte&nbsp;») afin de proposer vous engager auprès de TechPourToutes. L’accès et l’utilisation de la Plateforme sont gratuits. Vous devez être âgé(e) d’au moins 18 ans pour utiliser notre Plateforme et créer un Compte.
+
+        Nous nous réservons le droit, à notre seule discrétion, d’accepter ou de refuser votre inscription à notre Plateforme.
+
+        Vous êtes responsable de toutes les actions résultant de l’utilisation de votre Compte, que vous en soyez ou non à l’origine. Vous ne devez donc pas autoriser un tiers à utiliser votre Compte à votre place ou en votre nom, et vous devez prendre toutes les mesures appropriées pour garantir la sécurité et la confidentialité de votre identifiant.
+        </c-components.text>
+
+        <c-components.title title="12. Services" variant="intertitre" />
+        <c-components.text>
+            Le site Coalition a pour objet d'encourager un maximum de Bénévoles à s'engager auprès de TechPourToutes. A ce titre, il présente des actions d'engagement auprès de la coalition TechPourToutes afin d'accompagner aux mieux les lycéennes et étudiantes intéressées par les métiers techniques du numérique. Il a également pour objet de mettre en relation des Bénévoles avec des Bénéficiaires du programme.
+
+            Cette liste est non-exhaustive et peut être enrichie à tout moment sans que la responsabilité de la Fondation Inria ne puisse être engagée à ce titre par qui que ce soit.
+
+            Certains services sont accessibles qu'après connexion au site.
+        </c-components.text>
+
+        <c-components.title title="13. Suspension ou Résiliation de votre Compte" variant="intertitre" />
+        <c-components.text>
+            Nous nous réservons le droit de suspendre ou de résilier votre Compte et de refuser toute utilisation actuelle ou future de la Plateforme, à tout moment, dans les cas suivants : (i) vous publiez sur la Plateforme (via votre Compte ou via l’une de vos interactions au sein de la Plateforme) des contenus faux, inexacts, obsolètes ou incomplets, ou Welcome to the Jungle a des motifs raisonnables de suspecter que de tels contenus sont faux, inexacts, obsolètes ou incomplets ; (ii) vous enfreignez les présentes CGU (y compris les politiques annexes) ; (iii) vous enfreignez toute loi ou réglementation applicable dans le cadre de vos interactions avec la Plateforme ; ou (iv) votre Compte a été précédemment résilié pour manquement et vous tentez de créer un nouveau Compte.
+
+            Si votre Compte a été résilié en raison d’un manquement aux présentes CGU, il vous est interdit de créer un nouveau Compte sur la Plateforme sous un nom différent, une adresse e-mail différente ou toute autre forme de vérification de compte.        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="PART C - DISPOSITIONS GÉNÉRALES">
+        <c-components.title title="14. Propriété Intellectuelle et Utilisation Acceptable" variant="intertitre" />
+        <c-components.text>
+            <u>1. Contenus</u>
+
+            Les contenus du site TechPourToutes (logos, textes, éléments graphiques, vidéos, etc.) sont protégés par le droit d’auteur, en vertu du Code de la propriété intellectuelle.
+
+            Vous devrez obtenir l’autorisation de la Fondation Inria avant toute reproduction, copie ou publication de ces différents contenus.
+
+            Ces derniers ne pourront dans tous les cas pas être utilisés pour un usage commercial.
+
+            <u>2. Licence d’Utilisation de la Plateforme</u>
+
+            La Plateforme est protégée par les lois sur le droit d’auteur en vigueur dans le monde entier. Sous réserve des présentes CGU, nous vous accordons par les présentes une licence limitée, révocable, non exclusive, non transférable et ne pouvant faire l’objet d’une sous-licence, pour accéder, consulter et utiliser la Plateforme exclusivement à des fins personnelles.
+        </c-components.text>
+
+        <c-components.title title="15. Liens Hypertextes" variant="intertitre" />
+        <c-components.text>
+            <u>1. Liens vers notre Site</u>
+
+            Il est possible pour un tiers de créer un lien vers une page du site TechPourToutes sans autorisation expresse de l’éditeur.
+
+            Notre Site ne doit pas être intégré par la technique du “framing” (cadrage) sur tout autre site.
+
+            <u>2. Liens vers d’Autres Sites Internet</u>
+
+            Les domaines vers lesquels mènent les liens hypertextes présents sur le site n’engagent pas la responsabilité de l’Éditeur de TechPourToutes, qui n’a pas de contrôle sur ces liens.
+        </c-components.text>
+
+        <c-components.title title="16. Durée et Résiliation" variant="intertitre" />
+        <c-components.text>
+            Vous reconnaissez et acceptez par les présentes que l’application des présentes CGU a pris effet à la date la plus ancienne entre (a) la date à laquelle vous avez utilisé la Plateforme pour la première fois et (b) la date à laquelle vous les avez acceptées (telle que décrite ci-dessus), et que les présentes CGU demeureront pleinement en vigueur pendant toute la durée de votre utilisation de la Plateforme, sauf résiliation anticipée conformément aux dispositions des présentes.
+        </c-components.text>
+
+        <c-components.title title="17. Confidentialité et Protection des Données" variant="intertitre" />
+        <c-components.text>
+            Pour toute information relative à la manière dont nous collectons, stockons et traitons vos données personnelles, veuillez consulter notre Politique de gestion des Données personnelles et cookies.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="PARTIE D : DISPOSITIONS DIVERSES">
+        <c-components.title title="18. Communications Électroniques" variant="intertitre" />
+        <c-components.text>
+            Les communications entre vous et la Plateforme peuvent s’effectuer par voie électronique. À des fins contractuelles, vous (a) consentez à recevoir des communications de la Plateforme sous forme électronique ; et (b) acceptez que l’ensemble des conditions générales, accords, avis, divulgations et autres communications que la Plateforme vous fournit par voie électronique satisfont à toute exigence légale à laquelle ces communications satisferaient si elles étaient établies par écrit.
+        </c-components.text>
+
+        <c-components.title title="19. Force Majeure" variant="intertitre" />
+        <c-components.text>
+            La Fondation Inria ne saurait être tenue responsable de tout retard ou manquement à l’exécution de ses obligations résultant de causes échappant à son contrôle raisonnable, y compris, sans s’y limiter, les cas de force majeure, les actes de guerre, le terrorisme, les émeutes, les embargos, les actes des autorités civiles ou militaires, les incendies, les inondations, les accidents, les grèves ou les pénuries de moyens de transport, de carburant, d’énergie, de main-d’œuvre ou de matériaux.
+        </c-components.text>
+
+        <c-components.title title="20. Cession de contrat" variant="intertitre" />
+        <c-components.text>
+            Vous ne pouvez céder, sous-traiter, déléguer ou transférer de toute autre manière vos droits ou obligations au titre des présentes CGU à tout tiers sans notre consentement écrit préalable. Toute tentative de cession, sous-traitance, délégation ou transfert effectuée en violation de ce qui précède sera nulle et non avenue. Nous pouvons transférer nos droits au titre des présentes CGU à tout moment et à notre discrétion.
+        </c-components.text>
+
+        <c-components.title title="21. Notifications" variant="intertitre" />
+        <c-components.text>
+            Lorsque la Plaforme vous demande de fournir une adresse e-mail, vous êtes responsable de communiquer votre adresse e-mail la plus récente. Dans le cas où la dernière adresse e-mail que vous avez communiquée n’est pas valide ou n’est, pour quelque raison que ce soit, pas en mesure de vous transmettre les avis requis ou autorisés par les présentes CGU, l’envoi par la Fondation de l’e-mail contenant ledit avis constituera néanmoins une notification valable.
+        </c-components.text>
+
+        <c-components.title title="22. Intégralité de l’Accord" variant="intertitre" />
+        <c-components.text>
+            Les présentes CGU, y compris les politiques et autres documents qui y sont mentionnés, constituent l’intégralité de l’accord entre vous et la Fondation Inria relatif à leur objet et remplacent l’ensemble des discussions, arrangements ou accords antérieurs qui auraient pu avoir lieu à ce sujet.
+        </c-components.text>
+
+        <c-components.title title="23. Droit applicable et juridiction compétente" variant="intertitre" />
+        <c-components.text>
+            Le présent contrat dépend de la législation française.
+
+            En cas de litige non résolu à l’amiable entre le Bénévole et la Fondation Inria, les tribunaux de Paris sont compétents pour régler le contentieux.
+        </c-components.text>
+    </c-components.card>
+</c-layout.base>

--- a/techpourtoutes/templates/legals/donnees_personnelles.html
+++ b/techpourtoutes/templates/legals/donnees_personnelles.html
@@ -1,0 +1,150 @@
+<c-layout.base>
+    <c-components.title title="Politique de gestion des données personnelles et cookies" />
+
+    <p class="max-w-2xl">La Fondation Inria, organisation pilote du programme TechPourToutes est engagée dans une démarche de protection des données personnelles en accord avec le Règlement Général sur la Protection des Données (RGPD).</p>
+
+    <c-components.card title="Propos introductifs">
+        <c-components.text>
+            Lorsque vous utilisez le site <u><a href="{{ site_url }}">techpourtoutes.io</a></u>, nous sommes amenées à collecter et utiliser vos données personnelles.
+
+            La présente charte explique la manière dont nous utilisons ces données, notamment pour assurer le bon fonctionnement de la Plateforme. Elle détaille également vos droits concernant vos données personnelles.
+
+            Le terme «&nbsp;données personnelles&nbsp;» désigne l'ensemble des informations qui permettent de vous identifier directement ou indirectement.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Objet">
+        <c-components.text>
+            En tant que responsable du traitement de vos données personnelles, nous nous engageons à respecter la réglementation en vigueur en matière de protection des données, en particulier le Règlement Général sur la Protection des Données (RGPD), qui nous impose de vous informer, et ce de manière transparente.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Qui sommes-nous ?">
+        <c-components.text>
+            La Fondation Inria, située au 48, rue Barrault à Paris (75013) est le «&nbsp;responsable de traitement&nbsp;» concernant la collecte et l'utilisation de vos données personnelles.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Bases légales">
+        <c-components.list>
+            Votre consentement et notre mission lorsque vous nous fournissez volontairement des données personnelles lors de votre visite sur notre Plateforme. Ces données sont collectées pour nous permettre de gérer diverses fonctionnalités et services.
+            L'exécution du contrat conclu avec nous (correspondant aux Conditions Générales d'Utilisation - Coalition ou Conditions Générales d'Utilisation - Programme)
+        </c-components.list>
+    </c-components.card>
+
+    <c-components.card title="Finalités de la collecte de vos données personnelles">
+        <c-components.title title="Collecte de données personnelles fondée sur le contrat" variant="intertitre" />
+
+        <c-components.text>
+            Permettre la création et la gestion de votre Compte sur la Plateforme.
+        </c-components.text>
+
+        <c-components.title title="Collecte de données personnelles fondée sur votre consentement" variant="intertitre" />
+
+        <c-components.text>Adresser :</c-components.text>
+
+        <c-components.list>
+            des newsletters ;
+            des enquêtes dans le cadre de l'usage de la Plateforme ;
+            pour l'ensemble de ces envois, un lien de désinscription figure toujours à la fin du mail.
+        </c-components.list>
+
+        <c-components.title title="Collecte de données à caractère personnel fondée sur notre mission" variant="intertitre" />
+        <c-components.list>
+            Répondre à vos demandes d'information/réclamations ;
+            Faire des statistiques d'utilisation et de performance des différentes fonctionnalités et services proposés et en assurer l'amélioration ;
+
+            Vos données personnelles ne feront pas l'objet de cessions, locations ou échanges au bénéfice de tiers.
+        </c-components.list>
+    </c-components.card>
+
+    <c-components.card title="Données personnelles concernées">
+        <c-components.list>
+            Les données nécessaires à votre inscription, à la gestion de votre Compte sur la Plateforme et à l'utilisation de nos services (données relatives à votre identité, adresse mail, adresse postale, profession, etc.) ;
+
+            Les données contenues dans vos demandes lorsque vous nous contactez via nos adresses mail, les formulaires présents sur la Plateforme ou lorsque vous échangez avec nous sur les réseaux sociaux (y compris les enregistrements vocaux) ;
+
+            Les réponses à nos sondages et questionnaires qui peuvent vous être adressés ;
+
+            Les données de navigation sur la Plateforme ;
+
+            Les données que nous pouvons vous demander si vous formulez une réclamation ;
+
+            Les données techniques relatives notamment à votre adresse IP et des informations sur votre navigateur, à des fins de sécurité et de bon fonctionnement du service.
+        </c-components.list>
+
+        <c-components.text>
+            Lors de la collecte de vos données personnelles, nous vous informerons si les informations doivent être obligatoirement renseignées ou si elles sont facultatives.
+
+            Les informations obligatoires sont nécessaires au fonctionnement des différentes fonctionnalités. Concernant les données facultatives, vous êtes libre de les communiquer ou non. Nous vous indiquerons également les éventuelles conséquences d'une absence de réponse sur l'utilisation des services proposés.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Destinataires de vos données personnelles">
+        <c-components.list>
+            Les collaborateurs habilités de la Fondation Inria ;
+
+            Les collaborateurs habilités des membres du consortium ;
+
+            Nos partenaires institutionnels (exemple : le ministère de l'Enseignement Supérieur et de la Recherche) ;
+
+            Les sous-traitants de la Fondation Inria et des membres du consortium.
+        </c-components.list>
+
+        <c-components.text>
+            Peuvent également être destinataires de vos données personnelles les autorités financières, judiciaires, organismes publics, sur demande pour répondre à nos obligations légales et réglementaires, certaines professions réglementées telles que les avocats, commissaires aux comptes, les auxiliaires de justice et les officiers ministériels.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Durées de conservation de vos données personnelles">
+        <c-components.list>
+            <strong>Données relatives à la gestion de vos demandes d'aide</strong>&nbsp;: elles ne seront pas conservées au-delà de la durée strictement nécessaire à la gestion de notre relation et seront automatiquement supprimées au plus tard 3 ans sans réponse de votre part à nos sollicitations.
+
+            <strong>Données utilisées lors de l'inscription à une newsletter</strong>&nbsp;: les informations seront conservées jusqu'à votre désinscription via le lien de désabonnement prévu en fin de nos mails ou au plus tard 3 ans sans réponse de votre part à nos sollicitations.
+
+            <strong>Données visant à effectuer des études statistiques d'utilisation de l'application ainsi que des enquêtes</strong>&nbsp;: au maximum 5 ans à compter des résultats ou réponses d'enquêtes.
+
+            <strong>Données de connexion communiquées automatiquement lors de la visite sur notre Plateforme</strong>&nbsp;: conservées 6 mois.
+
+            <strong>Cookies et autres traceurs</strong>&nbsp;: conservées 6 mois.
+        </c-components.list>
+    </c-components.card>
+
+    <c-components.card title="Transferts de données personnelles en dehors de l'Union Européenne">
+        <c-components.text>
+            Vos données sont collectées et traitées uniquement sur le territoire de l'Union européenne.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Sécurité">
+        <c-components.text>
+            Nous mettons en œuvre des mesures appropriées pour préserver la sécurité et la confidentialité de vos données personnelles et, notamment, pour empêcher qu'elles soient déformées, endommagées, ou que des personnes non autorisées y aient accès.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Droits sur vos données personnelles">
+        <c-components.text>
+            Tout d'abord, vous pouvez modifier certaines de vos informations personnelles directement depuis votre Compte. Vous pouvez également demander la suppression de votre Compte en adressant un mail à <u><a href="mailto:bonjour@techpourtoutes.io">bonjour@techpourtoutes.io</a></u>.
+
+            Aussi, vous pouvez exercer vos droits d'accès, de limitation, de rectification et d'effacement de vos données personnelles. Vous disposez également du droit de donner des directives sur le sort de vos données après votre décès.
+
+            Pour exercer ces droits, vous pouvez envoyer un mail à notre Délégué à la protection des données (DPO) à l'adresse mail <u><a href="mailto:dpo@fondation-inria.fr">dpo@fondation-inria.fr</a></u> ou lui adresser un courrier :
+
+            Fondation Inria
+            48, rue Barrault
+            75013 Paris
+
+            Une réponse vous sera adressée dans un délai maximum d'un mois suivant la réception de votre demande. Au besoin, ce délai pourra être prolongé de deux mois supplémentaires. Dans ce cas, vous en serez informé et nous vous en indiquerons les raisons.
+
+            Si vous avez besoin de plus d'informations concernant vos droits, la Commission nationale de l'informatique et des libertés («&nbsp;CNIL&nbsp;») met à votre disposition, sur son site internet, des articles pour vous sensibiliser.
+
+            Si vous considérez que la collecte, l'utilisation de vos données personnelles, ou une demande liée à vos droits n'est pas conforme à la législation sur la protection des données personnelles, vous pouvez adresser une réclamation à la CNIL.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Modification de la présente charte">
+        <c-components.text>
+            Cette charte peut être modifiée à tout moment. Le cas échéant, ces modifications seront valables à compter de la publication de la nouvelle charte sur <u><a href="{{ site_url }}">techpourtoutes.io</a></u>.
+        </c-components.text>
+    </c-components.card>
+</c-layout.base>

--- a/techpourtoutes/templates/legals/mentions_legales.html
+++ b/techpourtoutes/templates/legals/mentions_legales.html
@@ -1,0 +1,61 @@
+<c-layout.base>
+    <c-components.title title="Mentions légales" />
+
+    <p class="max-w-2xl">Le site <u><a href="{{ site_url }}">techpourtoutes.io</a></u> est édité par la Fondation Inria.</p>
+
+    <c-components.card title="Informations légales">
+        <c-components.text>
+            Fondation Inria
+            Domaine de Voluceau – BP 10578153 Le Chesnay Cedex – France
+            Tél : +33 (0)1 80 49 43 24
+            Email : <a href="mailto:contact@fondation-inria.fr">contact@fondation-inria.fr</a>
+            SIREN : 829 176 098
+            TVA : FR 69 82917609
+
+            Directeur de la publication : Bruno Sportisse, président de la Fondation Inria
+            Rédacteur en chef : Henri Verdier, directeur général de la Fondation Inria
+
+            La Fondation Inria est une fondation partenariale dont la création a été autorisée par le recteur de l’académie de Versailles le 6 février 2017, ainsi que publiée au bulletin officiel de l’enseignement supérieur et de la recherche en date du 30 mars 2017.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Hébergement">
+        <c-components.text>
+            Le site <a href="{{ site_url }}">TechPourToutes</a> est hébergé par Scalingo sur des serveurs géographiquement localisés en France.
+
+            Scalingo SAS
+            13, rue Jacques Peirot, 67000 Strasbourg 1
+            <a href="https://scalingo.com/fr/">https://scalingo.com/fr/</a>
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Protection des données à caractère personnel">
+        <c-components.text>
+            La Fondation Inria est engagée dans une démarche de protection des données à caractère personnel qu’elle traite. Pour plus d’informations, vous pouvez consulter notre politique de gestion des données personnelles ou nous contacter : <a href="mailto:dpo@fondation-inria.fr">dpo@fondation-inria.fr</a>.
+        </c-components.text>
+    </c-components.card>
+    <c-components.card title="Propriété intellectuelle">
+        <c-components.text>
+            Le contenu du présent site, incluant, de façon non limitative, les graphismes, images, textes, vidéos, animations, sons, logos, gifs et icônes ainsi que leur mise en forme, est la propriété exclusive de la Fondation Inria à l’exception des marques, logos ou contenus appartenant à d’autres sociétés partenaires ou auteurs.
+
+            Toute reproduction, distribution, modification, adaptation, retransmission ou publication, même partielle, de ces différents éléments est strictement interdite sans l’accord exprès par écrit de leur ayant-droit. La représentation ou reproduction, par quelque procédé que ce soit, constitue une contrefaçon sanctionnée par les articles L.3335-2 et suivants du Code de la propriété intellectuelle. Le non-respect de cette interdiction constitue une contrefaçon pouvant engager la responsabilité civile et pénale du contrefacteur. En outre, les propriétaires des contenus copiés pourraient intenter une action en justice à votre encontre.
+        </c-components.text>
+    </c-components.card>
+    <c-components.card title="Contenu du site">
+        <c-components.text>
+            La Fondation Inria s’efforce d’assurer au mieux de ses possibilités l’exactitude et la mise à jour des informations diffusées au moment de leur mise en ligne sur le site. Cependant, la Fondation Inria ne garantit en aucune façon l’exactitude, la précision ou l’exhaustivité des informations mises à disposition sur le site. Les informations présentes sur le site sont non-contractuelles et peuvent être modifiées à tout moment. Si des informations vous semblent inexactes, n'hésitez pas à nous écrire à <a href="mailto:perfectible@techpourtoutes.io">perfectible@techpourtoutes.io</a>.
+        </c-components.text>
+    </c-components.card>
+    <c-components.card title="Liens hypertextes">
+        <c-components.text>
+            Le présent site peut offrir des liens vers d’autres sites web ou d’autres ressources disponibles sur Internet. La Fondation Inria ne dispose d’aucun moyen pour contrôler les sites en connexion avec celui-ci.
+
+            La Fondation Inria ne répond pas de la disponibilité de tels sites et sources externes, ni ne la garantit. Elle ne peut être tenue pour responsable de tout dommage, de quelque nature que ce soit, résultant du contenu de ces sites ou sources externes, et notamment des informations, produits ou services qu’ils proposent, ou de tout usage qui peut être fait de ces éléments. Les risques liés à cette utilisation incombent pleinement à l’internaute, qui doit se conformer à leurs conditions d’utilisation.
+        </c-components.text>
+    </c-components.card>
+    <c-components.card title="Crédits iconographiques">
+        <c-components.text>
+            Certaines images ou vidéos présentes sur le site peuvent provenir de la photothèque ou de la vidéothèque d’Inria. Aucune reproduction, totale ou partielle, de ces photos ou vidéos ne peut se faire sans l’autorisation préalable et écrite d’Inria.
+        </c-components.text>
+    </c-components.card>
+</c-layout.base>

--- a/techpourtoutes/templates/legals/schema_pluriannuel.html
+++ b/techpourtoutes/templates/legals/schema_pluriannuel.html
@@ -1,0 +1,153 @@
+<c-layout.base>
+    <c-components.title title="Schéma pluriannuel d'accessibilité 2026-2028" />
+
+    <c-components.card title="Introduction">
+        <c-components.text>
+            L'article 47 de la loi n° 2005-102 du 11 février 2005 pour l'égalité des droits et des chances, la participation et la citoyenneté des personnes rend obligatoire à tout service de communication publique en ligne d'être accessible à tous.
+
+            La Fondation Inria s'inscrit pleinement dans cette obligation légale et dans une démarche volontaire d'amélioration continue de l'accessibilité de ses services numériques, afin de garantir un accès égal à l'information et aux services pour l'ensemble des utilisateurs, y compris les personnes en situation de handicap.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Définition de l'accessibilité numérique">
+        <c-components.text>
+            L'accessibilité numérique permet d'accéder aux contenus et services numériques (sites web, documents bureautiques, supports multimédias, intranets, applications mobiles…), quelle que soit la façon de naviguer ou les technologies d'assistance utilisées.
+
+            Elle est indispensable aux personnes en situation de handicap pour&nbsp;:
+        </c-components.text>
+
+        <c-components.list>
+            s'informer&nbsp;;
+            communiquer&nbsp;;
+            accomplir des démarches administratives&nbsp;;
+            mener une activité professionnelle.
+        </c-components.list>
+
+        <c-components.text>
+            L'accessibilité numérique bénéficie également à un public beaucoup plus large&nbsp;: personnes âgées, personnes en situation de handicap temporaire ou permanent, personnes peu à l'aise avec le numérique ou utilisant des équipements variés.
+
+            Elle constitue un enjeu politique, social et citoyen majeur, participant à l'égalité des droits et à la non-discrimination.
+
+            L'accessibilité numérique est un domaine transverse qui concerne l'ensemble des acteurs impliqués dans la conception, la réalisation, la maintenance et l'exploitation des dispositifs numériques&nbsp;: décideurs, chefs de projet, designers, développeurs, producteurs de contenus et équipes support.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Politique d'accessibilité">
+        <c-components.text>
+            L'accessibilité numérique est au cœur des préoccupations liées au développement et à la mise à disposition des sites de la Fondation Inria, tant à destination du public que des collaborateurs internes.
+
+            Cette politique se traduit par l'élaboration et la mise en œuvre du présent schéma pluriannuel d'accessibilité numérique, accompagné de plans annuels d'actions. L'objectif est d'assurer la conformité au RGAA (Référentiel Général d'Amélioration de l'Accessibilité) et d'améliorer durablement la qualité des services numériques proposés.
+
+            L'élaboration, le suivi et la mise à jour de ce schéma sont placés sous la responsabilité de la responsable de la plateforme.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Ressources humaines et financières affectées">
+        <c-components.text>
+            Le pilotage et le suivi de la conformité au RGAA sont assurés par la responsable de la plateforme qui travaille conjointement avec l'équipe Communication pour l'élaboration de contenus accessibles et avec l'équipe technique pour le développement du site.
+
+            Les ressources nécessaires à la mise en œuvre de la politique d'accessibilité sont intégrées aux budgets de fonctionnement et de développement des projets numériques, avec, le cas échéant, un recours à des expertises externes. En particulier, la Fondation Inria dispose de l'aide d'Inria sur ces questions.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Organisation de la prise en compte de l'accessibilité numérique">
+        <c-components.text>
+            La prise en compte de l'accessibilité numérique repose sur les principes suivants&nbsp;:
+        </c-components.text>
+
+        <c-components.list>
+            l'adaptation continue de l'organisation interne de production et de gestion des sites web et applications&nbsp;;
+            l'accompagnement des équipes tout au long des projets&nbsp;;
+            l'intégration de l'accessibilité dans les procédures de marchés et de partenariats&nbsp;;
+            la prise en charge des difficultés rencontrées par les personnes en situation de handicap.
+        </c-components.list>
+
+        <c-components.title variant="intertitre" title="Actions de formation et de sensibilisation" />
+
+        <c-components.text>
+            Des actions de formation et de sensibilisation sont organisées tout au long de la période d'application du schéma. Elles visent à permettre aux personnels intervenant sur les sites, applications et supports de communication de concevoir, développer et publier des contenus accessibles.
+
+            Ces actions ont pour objectifs&nbsp;:
+        </c-components.text>
+
+        <c-components.list>
+            de sensibiliser à l'importance du respect des règles d'accessibilité numérique&nbsp;;
+            de former aux bonnes pratiques indispensables en matière de graphisme, d'ergonomie, de développement et de production de contenus.
+        </c-components.list>
+
+        <c-components.title variant="intertitre" title="Recours à des compétences externes" />
+
+        <c-components.text>
+            Lorsque cela est nécessaire, la Fondation Inria fait appel à des prestataires spécialisés pour l'accompagner, notamment dans le cadre d'actions de formation, d'audits d'accessibilité, de conseils ou de certifications. Elle est également accompagnée par les experts en accessibilité d'Inria.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Prise en compte de l'accessibilité dans les projets" />
+
+        <c-components.text>
+            Les exigences d'accessibilité et de conformité au RGAA sont intégrées dès la phase de cadrage des projets et constituent une exigence de base tout au long de leur cycle de vie. Elles sont également rappelées dans les conventions et partenariats.
+
+            Des composants normés, des modèles accessibles et une documentation dédiée sont mis à disposition des équipes afin de faciliter la prise en compte de l'accessibilité.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Tests utilisateurs" />
+
+        <c-components.text>
+            Lorsque des tests utilisateurs sont organisés, le panel comprend, dans toute la mesure du possible, des personnes en situation de handicap. Pour cela, la Fondation Inria dispose de l'aide d'Inria et de la DINUM.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Prise en compte dans les procédures de marchés" />
+
+        <c-components.text>
+            L'accessibilité numérique et la conformité au RGAA sont intégrées dans l'évaluation de la qualité des offres lors des appels d'offres et des marchés publics. Les procédures et critères d'évaluation sont adaptés afin de renforcer ces exigences.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Recrutement" />
+
+        <c-components.text>
+            Une attention particulière est portée aux compétences en accessibilité numérique lors de la définition des fiches de poste et des procédures de recrutement des personnels intervenant sur les services numériques.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Traitement des retours utilisateurs" />
+
+        <c-components.text>
+            Un moyen de contact dédié permet aux utilisateurs en situation de handicap de signaler toute difficulté rencontrée&nbsp;: <u><a href="mailto:accessibilite@techpourtoutes.io">accessibilite@techpourtoutes.io</a></u>
+
+            Les demandes sont traitées par la responsable de la plateforme afin d'apporter une réponse adaptée et de contribuer à l'amélioration continue des services.
+        </c-components.text>
+
+        <c-components.title variant="intertitre" title="Processus de contrôle et de validation" />
+
+        <c-components.text>
+            Le site <u><a href="{{ site_url }}">techpourtoutes.io</a></u> fait l'objet de contrôles d'accessibilité lors de mises à jour substantielles ou de refontes. Ces contrôles permettent de mettre à jour les déclarations de conformité, en complément des recettes et contrôles intermédiaires réalisés tout au long des projets.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Plans annuels">
+        <c-components.title variant="intertitre" title="2026" />
+        <c-components.list>
+            Création d'une nouvelle charte graphique respectant les critères d'accessibilité
+
+            Rédaction d'une nouvelle version des mails en respectant les critères d'accessibilité
+
+            Création de ressources graphiques accessibles sur étagère pour le développement du site <u><a href="{{ site_url }}">techpourtoutes.io</a></u>
+
+            Recrutement et formation de deux développeur.euses
+
+            Refonte progressive du site <u><a href="{{ site_url }}">techpourtoutes.io</a></u> en suivant les critères du RGAA
+
+            Réalisation d'un audit d'accessibilité interne
+        </c-components.list>
+
+        <c-components.title variant="intertitre" title="2027" />
+        <c-components.list>
+            Sensibilisation des membres du consortium TechPourToutes aux enjeux de l'accessibilité
+
+            Travail conjoint de mise en accessibilité des contenus de communication publiés par les membres du consortium relatifs au programme TechPourToutes
+        </c-components.list>
+
+        <c-components.title variant="intertitre" title="2028" />
+        <c-components.list>
+            Réalisation d'un audit externe d'accessibilité suite aux différentes évolutions de la plateforme
+        </c-components.list>
+    </c-components.card>
+</c-layout.base>

--- a/techpourtoutes/tests/test_legal_views.py
+++ b/techpourtoutes/tests/test_legal_views.py
@@ -1,0 +1,34 @@
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "donnees_personnelles",
+        "conditions_generales",
+        "mentions_legales",
+        "accessibilite",
+        "schema_pluriannuel",
+    ],
+)
+def test_legal_page_returns_200(client, url_name):
+    assert client.get(reverse(url_name)).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "donnees_personnelles",
+        "conditions_generales",
+        "mentions_legales",
+        "accessibilite",
+        "schema_pluriannuel",
+    ],
+)
+@override_settings(SITE_URL="https://example.test")
+def test_legal_page_renders_site_url(client, url_name):
+    response = client.get(reverse(url_name))
+    assert response.context["site_url"] == "https://example.test"
+    assert b"https://example.test" in response.content

--- a/techpourtoutes/urls.py
+++ b/techpourtoutes/urls.py
@@ -3,7 +3,14 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    # Coallition
     path("", views.coallition_index, name="coallition_index"),
     path("je-deviens-mentor/", views.mentor_landing, name="mentor_landing"),
     path("bienvenue-dans-la-coallition/", views.mentor_success, name="mentor_success"),
+    # Legals
+    path("donnees-personnelles/", views.donnees_personnelles, name="donnees_personnelles"),
+    path("conditions-generales/", views.conditions_generales, name="conditions_generales"),
+    path("mentions-legales/", views.mentions_legales, name="mentions_legales"),
+    path("accessibilite/", views.accessibilite, name="accessibilite"),
+    path("schema-pluriannuel-accessibilite", views.schema_pluriannuel, name="schema_pluriannuel"),
 ]

--- a/techpourtoutes/views/__init__.py
+++ b/techpourtoutes/views/__init__.py
@@ -1,7 +1,19 @@
 from .coallition_views import coallition_index, mentor_landing, mentor_success
+from .legal_views import (
+    accessibilite,
+    conditions_generales,
+    donnees_personnelles,
+    mentions_legales,
+    schema_pluriannuel,
+)
 
 __all__ = [
     "coallition_index",
     "mentor_landing",
     "mentor_success",
+    "accessibilite",
+    "schema_pluriannuel",
+    "donnees_personnelles",
+    "conditions_generales",
+    "mentions_legales",
 ]

--- a/techpourtoutes/views/legal_views.py
+++ b/techpourtoutes/views/legal_views.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.shortcuts import render
+
+
+def donnees_personnelles(request):
+    return render(request, "legals/donnees_personnelles.html", {"site_url": settings.SITE_URL})
+
+
+def conditions_generales(request):
+    return render(request, "legals/conditions_generales.html", {"site_url": settings.SITE_URL})
+
+
+def mentions_legales(request):
+    return render(request, "legals/mentions_legales.html", {"site_url": settings.SITE_URL})
+
+
+def accessibilite(request):
+    return render(request, "legals/accessibilite.html", {"site_url": settings.SITE_URL})
+
+
+def schema_pluriannuel(request):
+    return render(request, "legals/schema_pluriannuel.html", {"site_url": settings.SITE_URL})

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -34,6 +34,7 @@
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
+    --font-weight-bold: 700;
     --radius-xs: 4px;
     --radius-sm: 6px;
     --radius-md: 8px;
@@ -1426,6 +1427,9 @@
   .cursor-pointer {
     cursor: pointer;
   }
+  .list-disc {
+    list-style-type: disc;
+  }
   .flex-col {
     flex-direction: column;
   }
@@ -1596,6 +1600,9 @@
   .pl-3 {
     padding-left: calc(var(--spacing) * 3);
   }
+  .pl-5 {
+    padding-left: calc(var(--spacing) * 5);
+  }
   .text-center {
     text-align: center;
   }
@@ -1649,6 +1656,10 @@
   .leading-none {
     --tw-leading: 1;
     line-height: 1;
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
   }
   .font-light {
     --tw-font-weight: var(--font-weight-light);

--- a/ui/templates/cotton/components/card.html
+++ b/ui/templates/cotton/components/card.html
@@ -1,12 +1,8 @@
-<c-vars variant="text" nobg=False />
+<c-vars nobg=False />
 
 <div class="p-4 max-w-2xl w-full{% if nobg != True %} bg-neutral-0 rounded border border-primary{% endif %}">
     <c-components.title title="{{ title }}" variant="h2" />
     <div class="text-black text-base leading-[1.4] relative w-full">
-        {% if variant != "text" %}
-            {{ slot }}
-        {% else %}
-            {{ slot|linebreaksbr }}
-        {% endif %}
+        {{ slot }}
     </div>
 </div>

--- a/ui/templates/cotton/components/list.html
+++ b/ui/templates/cotton/components/list.html
@@ -1,0 +1,5 @@
+<ul class="pl-5">
+    {% for line in slot.splitlines %}
+        {% if line.strip %}<li class="list-disc py-2">{{ line.strip|safe }}</li>{% endif %}
+    {% endfor %}
+</ul>

--- a/ui/templates/cotton/components/text.html
+++ b/ui/templates/cotton/components/text.html
@@ -1,0 +1,1 @@
+{{ slot|linebreaksbr }}

--- a/ui/templates/cotton/components/title.html
+++ b/ui/templates/cotton/components/title.html
@@ -1,14 +1,18 @@
 <c-vars icon-name="" title="" variant="h1" class="" />
 
-<div class="flex items-center gap-x-4 text-primary-700 leading-[1.2] {{ class }}">
-    {% if icon_name %}
-        <c-components.icon name="{{ icon_name }}" class="size-12" />
-    {% endif %}
-    {% if variant == "h2" %}
-        <h2 class="font-medium text-xl">{{ title }}</h2>
-    {% elif variant == "h3" %}
-        <h3 class="text-lg leading-[1.4]">{{ title }}</h3>
-    {% else %}
-        <h1 class="text-5xl">{{ title }}</h1>
-    {% endif %}
-</div>
+{% if variant == "intertitre" %}
+    <h3 class="font-bold text-base mt-5 {{ class }}">{{ title }}</h3>
+{% else %}
+    <div class="flex items-center max-w-2xl gap-x-4 text-primary-700 leading-[1.2] {{ class }}">
+        {% if icon_name %}
+            <c-components.icon name="{{ icon_name }}" class="size-12" />
+        {% endif %}
+        {% if variant == "h2" %}
+            <h2 class="font-medium text-xl">{{ title }}</h2>
+        {% elif variant == "h3" %}
+            <h3 class="text-lg leading-[1.4]">{{ title }}</h3>
+        {% else %}
+            <h1 class="text-5xl">{{ title }}</h1>
+        {% endif %}
+    </div>
+{% endif %}

--- a/ui/templates/cotton/layout/partials/footer.html
+++ b/ui/templates/cotton/layout/partials/footer.html
@@ -1,8 +1,9 @@
 <footer class="text-[11px] p-4">
   <nav class="flex justify-center items-center">
-    <a href="#" class="link link-hover px-4 border-r border-accent-100">Données personnelles et cookies</a>
-    <a href="#" class="link link-hover px-4 border-r border-accent-100">Mentions légales</a>
+    <a href="{% url 'donnees_personnelles' %}" class="link link-hover px-4 border-r border-accent-100">Données personnelles et cookies</a>
+    <a href="{% url 'mentions_legales' %}" class="link link-hover px-4 border-r border-accent-100">Mentions légales</a>
+    <a href="{% url 'conditions_generales' %}" class="link link-hover px-4 border-r border-accent-100">CGU - Coalition</a>
     <a href="#" class="link link-hover px-4 border-r border-accent-100">Pourquoi nous écrivons au féminin</a>
-    <a href="#" class="link link-hover px-4">Accessibilité : non conforme</a>
+    <a href="{% url "accessibilite" %}" class="link link-hover px-4">Accessibilité : non conforme</a>
   </nav>
 </footer>


### PR DESCRIPTION
Closes #21 

Ajoute les pages : 
- Conditions générales d'utilisation - Coalition
- Mentions légales
- Accessibilité
- Schéma pluriannuel
- Données personnelles et cookies

Ajouts de components Cotton :
- text
- list
- variante intertitre dans le composant title

Les CGU n'étaient pas présentes dans la maquette, donc je les ai ajoutées dans le footer pour l'instant, on pourra les mettre ailleurs si ça ne te convient pas.

<img width="1910" height="4706" alt="localhost_8000_mentions-legales_ (1)" src="https://github.com/user-attachments/assets/c4be019b-bdc2-4697-8eab-7804caa20536" />
