### PR TITLE
fix brevo sync for duplicate phones + dont retry permanent errors

### DIFF
--- a/techpourtoutes/services/brevo_api/base_service.py
+++ b/techpourtoutes/services/brevo_api/base_service.py
@@ -20,11 +20,19 @@ class BrevoApiBaseService(BaseService):
         try:
             self._brevo_response = getattr(BrevoClient(), method)(**kwargs)
         except ApiError as exc:
+            self.status_code = exc.status_code
             self._fail_with_errors(exc)
 
     @cached_property
     def brevo_response_body(self):
         return getattr(self, "_brevo_response", None)
+
+    @property
+    def is_transient_failure(self) -> bool:
+        code = getattr(self, "status_code", None)
+        if code is None:
+            return False
+        return code == 429 or code >= 500
 
     def _fail_with_errors(self, exc: ApiError) -> None:
         detail = ""

--- a/techpourtoutes/services/brevo_api/mappings.py
+++ b/techpourtoutes/services/brevo_api/mappings.py
@@ -7,7 +7,7 @@ FIELD_TO_BREVO_ATTR = {
     "email": "EMAIL",
     "first_name": "PRENOM",
     "last_name": "NOM",
-    "phone": "SMS",
+    "phone": "NUMERO_DE_TEL",
     "civility": "CIVILITE",
     "job_title": "POSTE",
     "professional_situation": "SITUATION_PRO",

--- a/techpourtoutes/tasks/_retry.py
+++ b/techpourtoutes/tasks/_retry.py
@@ -1,5 +1,9 @@
+class TransientError(Exception):
+    """Raised by tasks when an external call fails with a retryable error ( (5xx, 429)."""
+
+
 RETRY_KWARGS = {
-    "autoretry_for": (Exception,),
+    "autoretry_for": (TransientError,),
     "retry_backoff": True,
     "retry_backoff_max": 3600,
     "retry_jitter": True,

--- a/techpourtoutes/tasks/delete_brevo_contact.py
+++ b/techpourtoutes/tasks/delete_brevo_contact.py
@@ -2,11 +2,14 @@ from celery import shared_task
 
 from techpourtoutes.services.brevo_api.delete_contact import DeleteBrevoContact
 
-from ._retry import RETRY_KWARGS
+from ._retry import RETRY_KWARGS, TransientError
 
 
 @shared_task(bind=True, **RETRY_KWARGS)
 def delete_brevo_contact_task(self, ext_id: str, list_id: int):
     result = DeleteBrevoContact(ext_id=ext_id, list_id=list_id)
     if result.failure:
-        raise RuntimeError(", ".join(result.errors))
+        message = ", ".join(result.errors)
+        if result.is_transient_failure:
+            raise TransientError(message)
+        raise RuntimeError(message)

--- a/techpourtoutes/tasks/upsert_brevo_contact.py
+++ b/techpourtoutes/tasks/upsert_brevo_contact.py
@@ -3,7 +3,7 @@ from django.apps import apps
 
 from techpourtoutes.services.brevo_api.upsert_contact import UpsertBrevoContact
 
-from ._retry import RETRY_KWARGS
+from ._retry import RETRY_KWARGS, TransientError
 
 
 @shared_task(bind=True, **RETRY_KWARGS)
@@ -11,4 +11,7 @@ def upsert_brevo_contact_task(self, instance_pk: str, model_label: str):
     instance = apps.get_model(model_label).objects.get(pk=instance_pk)
     result = UpsertBrevoContact(instance=instance)
     if result.failure:
-        raise RuntimeError(", ".join(result.errors))
+        message = ", ".join(result.errors)
+        if result.is_transient_failure:
+            raise TransientError(message)
+        raise RuntimeError(message)

--- a/techpourtoutes/tests/test_brevo_mappings.py
+++ b/techpourtoutes/tests/test_brevo_mappings.py
@@ -17,7 +17,7 @@ def test_brevo_attributes_for_mentor_returns_mapped_attributes(mentor):
         "EMAIL": "alice@example.com",
         "PRENOM": "Alice",
         "NOM": "Martin",
-        "SMS": "+33612345678",
+        "NUMERO_DE_TEL": "+33612345678",
         "CIVILITE": "Madame",
         "POSTE": "Chercheuse",
         "SITUATION_PRO": "working",

--- a/techpourtoutes/tests/test_brevo_services.py
+++ b/techpourtoutes/tests/test_brevo_services.py
@@ -55,6 +55,33 @@ def test_upsert_brevo_contact_captures_api_error(mentor, mock_brevo_client):
 
 
 @pytest.mark.django_db
+@override_settings(BREVO_MENTOR_LIST_ID=42, BREVO_API_KEY="test")
+@pytest.mark.parametrize(
+    "status_code,is_transient",
+    [(400, False), (404, False), (422, False), (429, True), (500, True), (503, True)],
+)
+def test_is_transient_failure_classifies_by_status_code(
+    mentor, mock_brevo_client, status_code, is_transient
+):
+    mock_brevo_client.upsert_contact.side_effect = ApiError(
+        status_code=status_code, body={"message": "x"}
+    )
+
+    result = UpsertBrevoContact(instance=mentor)
+
+    assert result.is_transient_failure is is_transient
+
+
+@pytest.mark.django_db
+@override_settings(BREVO_MENTOR_LIST_ID=42, BREVO_API_KEY="test")
+def test_is_transient_failure_false_on_success(mentor, mock_brevo_client):
+    result = UpsertBrevoContact(instance=mentor)
+
+    assert result.success
+    assert result.is_transient_failure is False
+
+
+@pytest.mark.django_db
 @override_settings(BREVO_API_KEY="test")
 def test_delete_brevo_contact_removes_from_list_when_contact_in_multiple_lists(
     mock_brevo_client,

--- a/techpourtoutes/tests/test_brevo_tasks.py
+++ b/techpourtoutes/tests/test_brevo_tasks.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import override_settings
 
+from techpourtoutes.tasks._retry import TransientError
 from techpourtoutes.tasks.delete_brevo_contact import delete_brevo_contact_task
 from techpourtoutes.tasks.upsert_brevo_contact import upsert_brevo_contact_task
 
@@ -11,7 +12,9 @@ from techpourtoutes.tasks.upsert_brevo_contact import upsert_brevo_contact_task
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test", BREVO_MENTOR_LIST_ID=42)
 def test_upsert_brevo_contact_task_loads_subclass_and_runs_service(mentor):
     with patch("techpourtoutes.tasks.upsert_brevo_contact.UpsertBrevoContact") as mock_service:
-        mock_service.return_value = MagicMock(success=True, failure=False, errors=[])
+        mock_service.return_value = MagicMock(
+            success=True, failure=False, errors=[], is_transient_failure=False
+        )
 
         upsert_brevo_contact_task(str(mentor.pk), "techpourtoutes.Mentor")
 
@@ -23,18 +26,34 @@ def test_upsert_brevo_contact_task_loads_subclass_and_runs_service(mentor):
 
 @pytest.mark.django_db
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test")
-def test_upsert_brevo_contact_task_raises_when_service_fails(mentor):
+def test_upsert_brevo_contact_task_raises_runtime_error_on_permanent_failure(mentor):
     with patch("techpourtoutes.tasks.upsert_brevo_contact.UpsertBrevoContact") as mock_service:
-        mock_service.return_value = MagicMock(success=False, failure=True, errors=["boom"])
+        mock_service.return_value = MagicMock(
+            success=False, failure=True, errors=["boom"], is_transient_failure=False
+        )
 
         with pytest.raises(RuntimeError, match="boom"):
+            upsert_brevo_contact_task(str(mentor.pk), "techpourtoutes.Mentor")
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test")
+def test_upsert_brevo_contact_task_raises_transient_error_on_transient_failure(mentor):
+    with patch("techpourtoutes.tasks.upsert_brevo_contact.UpsertBrevoContact") as mock_service:
+        mock_service.return_value = MagicMock(
+            success=False, failure=True, errors=["boom"], is_transient_failure=True
+        )
+
+        with pytest.raises(TransientError, match="boom"):
             upsert_brevo_contact_task(str(mentor.pk), "techpourtoutes.Mentor")
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test")
 def test_delete_brevo_contact_task_runs_service():
     with patch("techpourtoutes.tasks.delete_brevo_contact.DeleteBrevoContact") as mock_service:
-        mock_service.return_value = MagicMock(success=True, failure=False, errors=[])
+        mock_service.return_value = MagicMock(
+            success=True, failure=False, errors=[], is_transient_failure=False
+        )
 
         delete_brevo_contact_task("abc-123", 42)
 
@@ -42,9 +61,22 @@ def test_delete_brevo_contact_task_runs_service():
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test")
-def test_delete_brevo_contact_task_raises_when_service_fails():
+def test_delete_brevo_contact_task_raises_runtime_error_on_permanent_failure():
     with patch("techpourtoutes.tasks.delete_brevo_contact.DeleteBrevoContact") as mock_service:
-        mock_service.return_value = MagicMock(success=False, failure=True, errors=["nope"])
+        mock_service.return_value = MagicMock(
+            success=False, failure=True, errors=["nope"], is_transient_failure=False
+        )
 
         with pytest.raises(RuntimeError, match="nope"):
+            delete_brevo_contact_task("abc-123", 42)
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, BREVO_API_KEY="test")
+def test_delete_brevo_contact_task_raises_transient_error_on_transient_failure():
+    with patch("techpourtoutes.tasks.delete_brevo_contact.DeleteBrevoContact") as mock_service:
+        mock_service.return_value = MagicMock(
+            success=False, failure=True, errors=["nope"], is_transient_failure=True
+        )
+
+        with pytest.raises(TransientError, match="nope"):
             delete_brevo_contact_task("abc-123", 42)


### PR DESCRIPTION
Brevo a une contrainte d'unicité sur son attribut "SMS", or nous n'avons pas cette contrainte d'unicité. Pour contourner cette contrainte, j'inscris le numéro de téléphone dans le champ Brevo NUMERO_DE_TEL, qui existait déjà.

J'en profite pour faire fail immédiatement les tasks qui renvoient des erreurs permanentes (comme des 400) pour qu'elles remontent plus facilement dans Sentry.