### PR TITLE
Ajout de l'accès au compte mentor JobIRL

### DIFF
--- a/techpourtoutes/services/jobirl_api/refresh_access_token.py
+++ b/techpourtoutes/services/jobirl_api/refresh_access_token.py
@@ -1,0 +1,14 @@
+from techpourtoutes.services.jobirl_api.base_service import JobirlApiBaseService
+
+
+class RefreshAccessToken(JobirlApiBaseService):
+    def perform(self, *, mentor) -> None:
+        self.request(
+            method="post",
+            path="user_refresh_access_token",
+            payload={"iduser": mentor.jobirl_user_id, "token": mentor.jobirl_user_token},
+        )
+
+        self.token = self.jobirl_response_body["token"]
+        mentor.jobirl_user_token = self.token
+        mentor.save()

--- a/techpourtoutes/templates/account/account.html
+++ b/techpourtoutes/templates/account/account.html
@@ -4,8 +4,9 @@
         <p>Bonjour {{ request.user.first_name|default:request.user.username }}.</p>
         <p class="mt-2">Cette page sera enrichie prochainement.</p>
     </c-components.card>
-    <form method="POST" action="{% url 'logout' %}" class="mt-6">
-        {% csrf_token %}
+
+    <c-components.button href="{% url "login_to_jobirl" %}" label="Accéder à mon espace mentorat" />
+    <c-patterns.form url="{% url 'logout' %}">
         <c-components.button type="submit" label="Se déconnecter" />
-    </form>
+    </c-patterns.form>
 </c-layout.base>

--- a/techpourtoutes/tests/test_auth_views.py
+++ b/techpourtoutes/tests/test_auth_views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.contrib.messages import get_messages
@@ -262,3 +263,56 @@ def test_logout_get_not_allowed(client, mentor):
     response = client.get(reverse("logout"))
 
     assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_login_to_jobirl_requires_login(client):
+    response = client.get(reverse("login_to_jobirl"))
+
+    assert response.status_code == 302
+    assert reverse("login_request") in response["Location"]
+
+
+@pytest.mark.django_db
+def test_login_to_jobirl_for_non_mentor_renders_error(client, db):
+    from techpourtoutes.models import User
+
+    user = User.objects.create_user(username="plain@example.com", email="plain@example.com")
+    client.force_login(user)
+
+    response = client.get(reverse("login_to_jobirl"))
+
+    assert response.status_code == 200
+    stored = [str(m) for m in get_messages(response.wsgi_request)]
+    assert any("mentor" in m.lower() for m in stored)
+
+
+@pytest.mark.django_db
+@override_settings(JOBIRL_URL="https://jobirl.test")
+def test_login_to_jobirl_redirects_to_jobirl_url(client, mentor):
+    with patch("techpourtoutes.views.auth_views.RefreshAccessToken") as MockRefresh:
+        MockRefresh.return_value.success = True
+        MockRefresh.return_value.failure = False
+        MockRefresh.return_value.token = "new-token-xyz"
+        client.force_login(mentor)
+
+        response = client.get(reverse("login_to_jobirl"))
+
+    assert response.status_code == 302
+    assert response["Location"] == "https://jobirl.test/techpourtoutes/auth/new-token-xyz"
+
+
+@pytest.mark.django_db
+def test_login_to_jobirl_shows_error_on_service_failure(client, mentor):
+    with patch("techpourtoutes.views.auth_views.RefreshAccessToken") as MockRefresh:
+        MockRefresh.return_value.success = False
+        MockRefresh.return_value.failure = True
+        MockRefresh.return_value.errors = ["Erreur de connexion à Jobirl"]
+        client.force_login(mentor)
+
+        response = client.get(reverse("login_to_jobirl"))
+
+    stored = [str(m) for m in get_messages(response.wsgi_request)]
+    assert any("Erreur de connexion à Jobirl" in m for m in stored)
+    assert response.status_code == 302
+    assert response["Location"] == reverse("account")

--- a/techpourtoutes/tests/test_jobirl.py
+++ b/techpourtoutes/tests/test_jobirl.py
@@ -6,6 +6,82 @@ JOBIRL_TEST_URL = "https://preprod.jobirl.com"
 JOBIRL_TEST_API_KEY = "test-api-key-abc"
 
 
+@pytest.mark.django_db
+@override_settings(JOBIRL_URL=JOBIRL_TEST_URL, JOBIRL_API_KEY=JOBIRL_TEST_API_KEY)
+def test_refresh_access_token_sends_correct_payload_and_exposes_token(httpx_mock, mentor):
+    from techpourtoutes.services.jobirl_api.refresh_access_token import RefreshAccessToken
+
+    mentor.jobirl_user_id = 12345
+    mentor.jobirl_user_token = "old-token"
+    mentor.save()
+
+    refresh_url = f"{JOBIRL_TEST_URL}/techpourtoutes/api/user_refresh_access_token"
+    httpx_mock.add_response(
+        url=refresh_url,
+        status_code=200,
+        json={"response": "success", "datas": {"token": "new-token-abc"}},
+    )
+
+    result = RefreshAccessToken(mentor=mentor)
+
+    assert result.success
+    assert result.token == "new-token-abc"
+    request = httpx_mock.get_request()
+    assert request.method == "POST"
+    body = request.content.decode()
+    assert "iduser=12345" in body
+    assert "token=old-token" in body
+
+
+@pytest.mark.django_db
+@override_settings(JOBIRL_URL=JOBIRL_TEST_URL, JOBIRL_API_KEY=JOBIRL_TEST_API_KEY)
+def test_refresh_access_token_updates_mentor_token_in_db(httpx_mock, mentor):
+    from techpourtoutes.services.jobirl_api.refresh_access_token import RefreshAccessToken
+
+    mentor.jobirl_user_id = 12345
+    mentor.jobirl_user_token = "old-token"
+    mentor.save()
+
+    refresh_url = f"{JOBIRL_TEST_URL}/techpourtoutes/api/user_refresh_access_token"
+    httpx_mock.add_response(
+        url=refresh_url,
+        status_code=200,
+        json={"response": "success", "datas": {"token": "new-token-abc"}},
+    )
+
+    RefreshAccessToken(mentor=mentor)
+
+    mentor.refresh_from_db()
+    assert mentor.jobirl_user_token == "new-token-abc"
+
+
+@pytest.mark.django_db
+@override_settings(JOBIRL_URL=JOBIRL_TEST_URL, JOBIRL_API_KEY=JOBIRL_TEST_API_KEY)
+def test_refresh_access_token_fails_on_http_error(httpx_mock, mentor):
+    from techpourtoutes.services.jobirl_api.refresh_access_token import RefreshAccessToken
+
+    refresh_url = f"{JOBIRL_TEST_URL}/techpourtoutes/api/user_refresh_access_token"
+    httpx_mock.add_response(url=refresh_url, status_code=401)
+
+    result = RefreshAccessToken(mentor=mentor)
+
+    assert result.failure
+    assert result.errors
+
+
+@pytest.mark.django_db
+@override_settings(JOBIRL_URL=JOBIRL_TEST_URL, JOBIRL_API_KEY=JOBIRL_TEST_API_KEY)
+def test_refresh_access_token_fails_on_network_error(httpx_mock, mentor):
+    from techpourtoutes.services.jobirl_api.refresh_access_token import RefreshAccessToken
+
+    httpx_mock.add_exception(httpx.RequestError("connection failed"))
+
+    result = RefreshAccessToken(mentor=mentor)
+
+    assert result.failure
+    assert result.errors
+
+
 @override_settings(JOBIRL_URL=JOBIRL_TEST_URL, JOBIRL_API_KEY=JOBIRL_TEST_API_KEY)
 def test_register_mentor_on_jobirl_sends_correct_payload_and_exposes_ids(httpx_mock, mentor):
     from techpourtoutes.services.jobirl_api.register_mentor import RegisterMentorOnJobirl

--- a/techpourtoutes/urls.py
+++ b/techpourtoutes/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("se-connecter/token/<str:token>/", views.login_verify, name="login_verify"),
     path("mon-compte/", views.account, name="account"),
     path("se-deconnecter/", views.logout_view, name="logout"),
+    path("mon-compte-mentor/", views.login_to_jobirl, name="login_to_jobirl"),
     # Legals
     path("donnees-personnelles/", views.donnees_personnelles, name="donnees_personnelles"),
     path("conditions-generales/", views.conditions_generales, name="conditions_generales"),

--- a/techpourtoutes/views/__init__.py
+++ b/techpourtoutes/views/__init__.py
@@ -1,4 +1,11 @@
-from .auth_views import account, login_email_sent, login_request, login_verify, logout_view
+from .auth_views import (
+    account,
+    login_email_sent,
+    login_request,
+    login_to_jobirl,
+    login_verify,
+    logout_view,
+)
 from .coallition_views import coallition_index, mentor_landing, mentor_success
 from .legal_views import (
     accessibilite,
@@ -16,6 +23,7 @@ __all__ = [
     "donnees_personnelles",
     "login_email_sent",
     "login_request",
+    "login_to_jobirl",
     "login_verify",
     "logout_view",
     "mentions_legales",

--- a/techpourtoutes/views/auth_views.py
+++ b/techpourtoutes/views/auth_views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 
 from ..forms import LoginRequestForm
 from ..mailers import LoginMailer
+from ..services.jobirl_api.refresh_access_token import RefreshAccessToken
 
 
 def _safe_next(request, candidate):
@@ -77,6 +78,20 @@ def login_verify(request, token):
     login(request, user)
     messages.success(request, f"Vous accédez au compte {user.email}. Bienvenue !")
     return redirect(next_url or settings.LOGIN_REDIRECT_URL)
+
+
+@login_required
+def login_to_jobirl(request):
+    if not hasattr(request.user, "mentor"):
+        messages.error(request, "Vous n'avez pas de compte mentor sur JobIRL")
+        return render(request, "account/account.html", {})
+
+    result = RefreshAccessToken(mentor=request.user.mentor)
+    if result.failure:
+        messages.error(request, result.errors[0])
+        return redirect(reverse("account"))
+
+    return redirect(f"{settings.JOBIRL_URL}/techpourtoutes/auth/{result.token}")
 
 
 @login_required

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -1169,9 +1169,6 @@
   .mt-5 {
     margin-top: calc(var(--spacing) * 5);
   }
-  .mt-6 {
-    margin-top: calc(var(--spacing) * 6);
-  }
   .mt-20 {
     margin-top: calc(var(--spacing) * 20);
   }


### PR DESCRIPTION
Cette PR ajoute une url `/mon-compte-mentor` permettant d'être redirigé vers le compte mentor JobIRL.

Elle implémente un nouveau service `RefreshAccessToken` qui hérite de `JobirlApiBaseService`, update le token jobirl en db et le retourne. C'est ce service qui est utilisé pour créer un lien de redirection valide vers le compte mentor JobIRL dans un état loggé.