### PR TITLE
Ajout d'un message au renvoi d'un email de connexion

### DIFF
--- a/techpourtoutes/views/auth_views.py
+++ b/techpourtoutes/views/auth_views.py
@@ -39,7 +39,7 @@ def login_request(request):
                 plaintext = user.issue_login_token()
                 LoginMailer.send_link(user=user, token=plaintext, next_url=next_url)
             request.session["login_email"] = email
-            if request.headers["referer"] == f"{settings.SITE_URL}/se-connecter/email-envoye/":
+            if request.headers.get("referer") == f"{settings.SITE_URL}/se-connecter/email-envoye/":
                 messages.success(request, "Votre demande a bien été prise en compte.")
             return redirect("login_email_sent")
     else:

--- a/techpourtoutes/views/auth_views.py
+++ b/techpourtoutes/views/auth_views.py
@@ -39,6 +39,8 @@ def login_request(request):
                 plaintext = user.issue_login_token()
                 LoginMailer.send_link(user=user, token=plaintext, next_url=next_url)
             request.session["login_email"] = email
+            if request.headers["referer"] == f"{settings.SITE_URL}/se-connecter/email-envoye/":
+                messages.success(request, "Votre demande a bien été prise en compte.")
             return redirect("login_email_sent")
     else:
         form = LoginRequestForm()


### PR DESCRIPTION
Lorsque l'utilisateur réclame un nouveau lien de connexion depuis la page "email-envoye", ajout d'un message de succès pour montrer que l'action a bien été prise en compte ([répond à cette demande de @M-Minimal ](https://github.com/fondation-inria/techpourtoutes/issues/27#issuecomment-4577429564))