### PR TITLE
Gestion des formulaires pour les utilisateurs existants

### DIFF
--- a/techpourtoutes/forms/pro_form.py
+++ b/techpourtoutes/forms/pro_form.py
@@ -36,6 +36,28 @@ class ProForm(forms.Form):
         },
     )
 
+    def __init__(self, *args, pro=None, **kwargs):
+        if pro is not None:
+            kwargs.setdefault(
+                "initial",
+                {
+                    "civility": pro.civility,
+                    "first_name": pro.first_name,
+                    "last_name": pro.last_name,
+                    "email": pro.email,
+                    "phone": str(pro.phone),
+                    "postal_code": pro.postal_code,
+                    "professional_situation": pro.professional_situation,
+                    "structure_name": pro.structure_name,
+                    "job_title": pro.job_title,
+                },
+            )
+        super().__init__(*args, **kwargs)
+        self.pro = pro
+        if pro is not None:
+            self.fields["email"].disabled = True
+            self.fields["terms_accepted"].required = False
+
     def clean(self):
         cleaned_data = super().clean()
         if cleaned_data.get("professional_situation") == "working":
@@ -47,24 +69,39 @@ class ProForm(forms.Form):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if self.pro and email == self.pro.email:
+            return email
         if User.objects.filter(email=email).exists():
-            raise forms.ValidationError(_("Un compte avec cet email existe déjà."))
+            raise forms.ValidationError(
+                _("Un compte avec cet email existe déjà."), code="email_exists"
+            )
         return email
 
     def save(self, commit=True):
         data = self.cleaned_data
-        pro = Pro(
-            username=data["email"],
-            civility=data["civility"],
-            first_name=data["first_name"],
-            last_name=data["last_name"],
-            email=data["email"],
-            phone=data["phone"],
-            postal_code=data["postal_code"],
-            professional_situation=data["professional_situation"],
-            structure_name=data["structure_name"],
-            job_title=data["job_title"],
-        )
+        if self.pro is not None:
+            pro = self.pro
+            pro.civility = data["civility"]
+            pro.first_name = data["first_name"]
+            pro.last_name = data["last_name"]
+            pro.phone = data["phone"]
+            pro.postal_code = data["postal_code"]
+            pro.professional_situation = data["professional_situation"]
+            pro.structure_name = data["structure_name"]
+            pro.job_title = data["job_title"]
+        else:
+            pro = Pro(
+                username=data["email"],
+                civility=data["civility"],
+                first_name=data["first_name"],
+                last_name=data["last_name"],
+                email=data["email"],
+                phone=data["phone"],
+                postal_code=data["postal_code"],
+                professional_situation=data["professional_situation"],
+                structure_name=data["structure_name"],
+                job_title=data["job_title"],
+            )
         if commit:
             pro.save()
         return pro

--- a/techpourtoutes/forms/workshop_form.py
+++ b/techpourtoutes/forms/workshop_form.py
@@ -46,26 +46,58 @@ class WorkshopForm(forms.Form):
         },
     )
 
+    def __init__(self, *args, pro=None, **kwargs):
+        if pro is not None:
+            kwargs.setdefault(
+                "initial",
+                {
+                    "civility": pro.civility,
+                    "first_name": pro.first_name,
+                    "last_name": pro.last_name,
+                    "email": pro.email,
+                },
+            )
+        super().__init__(*args, **kwargs)
+        self.pro = pro
+        if pro is not None:
+            self.fields["email"].disabled = True
+            self.fields["terms_accepted"].required = False
+
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if self.pro and email == self.pro.email:
+            return email
         if User.objects.filter(email=email).exists():
-            raise forms.ValidationError(_("Un compte avec cet email existe déjà."))
+            raise forms.ValidationError(
+                _("Un compte avec cet email existe déjà."), code="email_exists"
+            )
         return email
 
     def save(self, commit=True):
         data = self.cleaned_data
-        pro = Pro(
-            username=data["email"],
-            civility=data["civility"],
-            first_name=data["first_name"],
-            last_name=data["last_name"],
-            email=data["email"],
-            professional_situation=Pro.ProfessionalSituation.WORKING,
-            structure_name=data["structure_name"],
-            structure_id=data["structure_id"],
-            job_title=data["job_title"],
-            postal_code=data["postal_code"],
-        )
+        if self.pro is not None:
+            pro = self.pro
+            pro.civility = data["civility"]
+            pro.first_name = data["first_name"]
+            pro.last_name = data["last_name"]
+            pro.professional_situation = Pro.ProfessionalSituation.WORKING
+            pro.structure_name = data["structure_name"]
+            pro.structure_id = data["structure_id"]
+            pro.job_title = data["job_title"]
+            pro.postal_code = data["postal_code"]
+        else:
+            pro = Pro(
+                username=data["email"],
+                civility=data["civility"],
+                first_name=data["first_name"],
+                last_name=data["last_name"],
+                email=data["email"],
+                professional_situation=Pro.ProfessionalSituation.WORKING,
+                structure_name=data["structure_name"],
+                structure_id=data["structure_id"],
+                job_title=data["job_title"],
+                postal_code=data["postal_code"],
+            )
         if commit:
             pro.save()
         return pro

--- a/techpourtoutes/templates/account/account.html
+++ b/techpourtoutes/templates/account/account.html
@@ -2,7 +2,7 @@
     <c-components.title title="Mon compte" variant="h1" />
 
     {% if "mentor" in user.engagements %}
-        <c-components.button href="{% url "login_to_jobirl" %}" label="Accéder à mon espace mentorat" />
+        <c-components.button href="{% url "login_to_jobirl" %}" label="Accéder à mon espace mentorat" icon="external-link" target="_blank" />
     {% endif %}
 
     {% include "account/partials/info_card.html" %}

--- a/techpourtoutes/templates/account/partials/info_card.html
+++ b/techpourtoutes/templates/account/partials/info_card.html
@@ -1,21 +1,21 @@
 <div id="account-info-card" class="w-full">
     <c-components.card title="Informations personnelles">
-        <c-components.text>
-            Prénom : <span class="font-semibold">{{ user.first_name }}</span>
+        <c-components.text class="font-light">
+            Prénom : <span class="font-medium">{{ user.first_name }}</span>
 
-            Nom : <span class="font-semibold">{{ user.last_name }}</span>
+            Nom : <span class="font-medium">{{ user.last_name }}</span>
 
-            Email : <span class="font-semibold">{{ user.email }}</span>
+            Email : <span class="font-medium">{{ user.email }}</span>
 
-            Numéro de téléphone : <span class="font-semibold">{{ user.phone }}</span>
+            Numéro de téléphone : <span class="font-medium">{{ user.phone }}</span>
 
-            Situation professionnelle : <span class="font-semibold">{{ user.professional_situation }}</span>
+            Situation professionnelle : <span class="font-medium">{{ user.professional_situation }}</span>
 
-            Structure : <span class="font-semibold">{{ user.structure_name }}</span>
+            Structure : <span class="font-medium">{{ user.structure_name }}</span>
 
-            Métier : <span class="font-semibold">{{ user.job_title }}</span>
+            Métier : <span class="font-medium">{{ user.job_title }}</span>
 
-            Code postal : <span class="font-semibold">{{ user.postal_code }}</span>
+            Code postal : <span class="font-medium">{{ user.postal_code }}</span>
         </c-components.text>
         <div class="flex mt-3 justify-end">
             <c-components.button label="Modifier" variant="secondary"

--- a/techpourtoutes/templates/coalition/mentor_landing.html
+++ b/techpourtoutes/templates/coalition/mentor_landing.html
@@ -59,18 +59,27 @@
 
             <div id="mentor-card">
 
-                <div x-show="!showForm" @click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer">
+                <div x-show="!showForm" {% if not pro or "mentor" not in pro.engagements %}@click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer"{% endif %}>
                     <c-components.card-shadow id="mentor-member-card" class="w-[320px] my-5">
                         <div class="flex gap-5">
                             <c-components.icon name="badge-coeur" class="shrink-0 w-15 h-15" />
-                            <div class="mt-5 [&>p]:pb-3 [&>p]:font-medium">
-                                <p>Prénom</p>
-                                <p>Nom</p>
-                                <p>Mentor TechPourToutes</p>
+                            <div>
+                                {% if pro %}
+                                    <p class="font-medium pb-3">{{ pro.first_name }}</p>
+                                    <p class="font-medium pb-3">{{ pro.last_name }}</p>
+                                {% else %}
+                                    <p class="font-light pb-3">Prénom</p>
+                                    <p class="font-light pb-3">Nom</p>
+                                {% endif %}
+                                <p class="font-medium">Mentor TechPourToutes</p>
                             </div>
                         </div>
-                        <div class="flex justify-center">
-                            <c-components.button href="" label="Je deviens mentor" />
+                        <div class="flex justify-center mt-3">
+                            {% if not pro or "mentor" not in pro.engagements %}
+                                    <c-components.button href="" label="Je deviens mentor" />
+                            {% else %}
+                                <c-components.button href="{% url "login_to_jobirl" %}" label="Mon espace mentorat" icon="external-link" target="_blank" />
+                            {% endif %}
                         </div>
                     </c-components.card-shadow>
                 </div>
@@ -88,7 +97,7 @@
                             <c-components.form_fields.radio field=form.civility />
                             <c-components.form_fields.input field=form.first_name autocomplete="given-name" />
                             <c-components.form_fields.input field=form.last_name autocomplete="family-name" />
-                            <c-components.form_fields.input field=form.email autocomplete="email" />
+                            <c-components.form_fields.input field=form.email autocomplete="email" variant="{% if pro %}disabled{% endif %}" />
                             <c-components.form_fields.input field=form.phone autocomplete="tel" />
                             <c-components.form_fields.input field=form.postal_code autocomplete="postal-code" />
                             <c-components.form_fields.select field=form.professional_situation :watchable=True />
@@ -98,7 +107,7 @@
                             <div x-show="situation == 'working'" x-cloak>
                                 <c-components.form_fields.input field=form.structure_name autocomplete="organization" />
                             </div>
-                            <c-components.form_fields.checkbox field=form.terms_accepted />
+                            {% if not pro %}<c-components.form_fields.checkbox field=form.terms_accepted />{% endif %}
                             <div class="flex justify-center">
                                 <c-components.button type="submit" label="Je deviens mentor" class="justify-center" />
                             </div>

--- a/techpourtoutes/templates/coalition/sponsor_landing.html
+++ b/techpourtoutes/templates/coalition/sponsor_landing.html
@@ -55,19 +55,26 @@
              :class="{ 'md:sticky md:top-14 xl:top-8': !showForm }">
             <c-components.title title="Rejoignez la coalition&nbsp;!" class="justify-center w-[300px] h-16" variant="h3" />
             <div id="sponsor-card">
-                <div x-show="!showForm" @click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer">
+                <div x-show="!showForm" {% if not pro or "sponsor" not in pro.engagements %}@click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer"{% endif %}>
                     <c-components.card-shadow id="sponsor-member-card" class="w-[320px] my-5">
                         <div class="flex gap-5">
                             <c-components.icon name="badge-coeur" class="shrink-0 w-15 h-15" />
-                            <div class="mt-5 [&>p]:pb-3 [&>p]:font-medium">
-                                <p>Prénom</p>
-                                <p>Nom</p>
-                                <p>Mécène TechPourToutes</p>
+                            <div>
+                                {% if pro %}
+                                    <p class="font-medium pb-3">{{ pro.first_name }}</p>
+                                    <p class="font-medium pb-3">{{ pro.last_name }}</p>
+                                {% else %}
+                                    <p class="font-light pb-3">Prénom</p>
+                                    <p class="font-light pb-3">Nom</p>
+                                {% endif %}
+                                <p class="font-medium">Mécène TechPourToutes</p>
                             </div>
                         </div>
-                        <div class="flex justify-center">
-                            <c-components.button href="" label="Je deviens mécène" />
-                        </div>
+                        {% if not pro or "sponsor" not in pro.engagements %}
+                            <div class="flex justify-center mt-3">
+                                <c-components.button href="" label="Je deviens mécène" />
+                            </div>
+                        {% endif %}
                     </c-components.card-shadow>
                 </div>
                 <div x-ref="formCard" x-show="showForm" x-cloak
@@ -83,13 +90,13 @@
                             <c-components.form_fields.radio field=form.civility />
                             <c-components.form_fields.input field=form.first_name autocomplete="given-name" />
                             <c-components.form_fields.input field=form.last_name autocomplete="family-name" />
-                            <c-components.form_fields.input field=form.email autocomplete="email" />
+                            <c-components.form_fields.input field=form.email autocomplete="email" variant="{% if pro %}disabled{% endif %}" />
                             <c-components.form_fields.input field=form.phone autocomplete="tel" />
                             <c-components.form_fields.input field=form.postal_code autocomplete="postal-code" />
                             <input type="hidden" name="professional_situation" value="working">
                             <c-components.form_fields.input field=form.job_title autocomplete="organization-title" />
                             <c-components.form_fields.input field=form.structure_name autocomplete="organization" />
-                            <c-components.form_fields.checkbox field=form.terms_accepted />
+                            {% if not pro %}<c-components.form_fields.checkbox field=form.terms_accepted />{% endif %}
                             <div class="flex justify-center">
                                 <c-components.button type="submit" label="Je deviens mécène" />
                             </div>

--- a/techpourtoutes/templates/coalition/work_ambassador_landing.html
+++ b/techpourtoutes/templates/coalition/work_ambassador_landing.html
@@ -58,19 +58,26 @@
              :class="{ 'md:sticky md:top-14 xl:top-8': !showForm }">
             <c-components.title title="Rejoignez la coalition&nbsp;!" class="justify-center w-[300px] h-16" variant="h3" />
             <div id="work-ambassador-card">
-                <div x-show="!showForm" @click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer">
+                <div x-show="!showForm" {% if not pro or "work_ambassador" not in pro.engagements %}@click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer"{% endif %}>
                     <c-components.card-shadow id="work-ambassador-member-card" class="w-[320px] my-5">
                         <div class="flex gap-5">
                             <c-components.icon name="badge-coeur" class="shrink-0 w-15 h-15" />
-                            <div class="mt-5 [&>p]:pb-3 [&>p]:font-medium">
-                                <p>Prénom</p>
-                                <p>Nom</p>
-                                <p>Ambassadrice TechPourToutes</p>
+                            <div>
+                                {% if pro %}
+                                    <p class="font-medium pb-3">{{ pro.first_name }}</p>
+                                    <p class="font-medium pb-3">{{ pro.last_name }}</p>
+                                {% else %}
+                                    <p class="font-light pb-3">Prénom</p>
+                                    <p class="font-light pb-3">Nom</p>
+                                {% endif %}
+                                <p class="font-medium">Ambassadrice TechPourToutes</p>
                             </div>
                         </div>
-                        <div class="flex justify-center">
-                            <c-components.button href="" label="Je deviens ambassadrice" />
-                        </div>
+                        {% if not pro or "work_ambassador" not in pro.engagements %}
+                            <div class="flex justify-center mt-3">
+                                <c-components.button href="" label="Je deviens ambassadrice" />
+                            </div>
+                        {% endif %}
                     </c-components.card-shadow>
                 </div>
                 <div x-ref="formCard" x-show="showForm" x-cloak
@@ -86,7 +93,7 @@
                             <c-components.form_fields.radio field=form.civility />
                             <c-components.form_fields.input field=form.first_name autocomplete="given-name" />
                             <c-components.form_fields.input field=form.last_name autocomplete="family-name" />
-                            <c-components.form_fields.input field=form.email autocomplete="email" />
+                            <c-components.form_fields.input field=form.email autocomplete="email" variant="{% if pro %}disabled{% endif %}" />
                             <c-components.form_fields.input field=form.phone autocomplete="tel" />
                             <c-components.form_fields.input field=form.postal_code autocomplete="postal-code" />
                             <c-components.form_fields.select field=form.professional_situation :watchable=True />
@@ -96,7 +103,7 @@
                             <div x-show="situation == 'working'" x-cloak>
                                 <c-components.form_fields.input field=form.structure_name autocomplete="organization" />
                             </div>
-                            <c-components.form_fields.checkbox field=form.terms_accepted />
+                            {% if not pro %}<c-components.form_fields.checkbox field=form.terms_accepted />{% endif %}
                             <div class="flex justify-center">
                                 <c-components.button type="submit" label="Je deviens ambassadrice" />
                             </div>

--- a/techpourtoutes/templates/coalition/workshops_landing.html
+++ b/techpourtoutes/templates/coalition/workshops_landing.html
@@ -107,7 +107,7 @@
                             <c-components.form_fields.radio field=form.civility />
                             <c-components.form_fields.input field=form.first_name autocomplete="given-name" />
                             <c-components.form_fields.input field=form.last_name autocomplete="family-name" />
-                            <c-components.form_fields.input field=form.email autocomplete="email" />
+                            <c-components.form_fields.input field=form.email autocomplete="email" variant="{% if pro %}disabled{% endif %}" />
                             <c-components.form_fields.select field=form.job_title />
                             <c-components.form_fields.school_search
                                 name_field=form.structure_name
@@ -117,7 +117,7 @@
                             />
                             <c-components.form_fields.checkbox_group field=form.ateliers description="Vous pouvez choisir plusieurs ateliers" />
                             <c-components.form_fields.textarea field=form.remark />
-                            <c-components.form_fields.checkbox field=form.terms_accepted />
+                            {% if not pro %}<c-components.form_fields.checkbox field=form.terms_accepted />{% endif %}
                             <div class="flex justify-center">
                                 <c-components.button type="submit" label="Je demande un atelier Latitudes" class="justify-center" />
                             </div>

--- a/techpourtoutes/tests/test_forms.py
+++ b/techpourtoutes/tests/test_forms.py
@@ -99,3 +99,88 @@ def test_pro_form_structure_name_not_required_when_retired(valid_pro_data):
     }
     form = ProForm(data=data)
     assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_pro_form_with_pro_email_is_disabled(pro):
+    from techpourtoutes.forms import ProForm
+
+    form = ProForm(pro=pro)
+    assert form.fields["email"].disabled
+
+
+@pytest.mark.django_db
+def test_pro_form_with_pro_sets_initial_values(pro):
+    from techpourtoutes.forms import ProForm
+
+    form = ProForm(pro=pro)
+    assert form.initial["email"] == pro.email
+    assert form.initial["first_name"] == pro.first_name
+    assert form.initial["last_name"] == pro.last_name
+
+
+@pytest.mark.django_db
+def test_pro_form_with_pro_terms_not_required(pro):
+    from techpourtoutes.forms import ProForm
+
+    data = {
+        "civility": pro.civility,
+        "first_name": pro.first_name,
+        "last_name": pro.last_name,
+        "email": pro.email,
+        "phone": str(pro.phone),
+        "postal_code": pro.postal_code,
+        "professional_situation": pro.professional_situation,
+        "job_title": pro.job_title,
+        "structure_name": pro.structure_name,
+    }
+    form = ProForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_pro_form_with_pro_allows_own_email(pro):
+    from techpourtoutes.forms import ProForm
+
+    data = {
+        "civility": pro.civility,
+        "first_name": pro.first_name,
+        "last_name": pro.last_name,
+        "email": pro.email,
+        "phone": str(pro.phone),
+        "postal_code": pro.postal_code,
+        "professional_situation": pro.professional_situation,
+        "job_title": pro.job_title,
+        "structure_name": pro.structure_name,
+        "terms_accepted": True,
+    }
+    form = ProForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_pro_form_with_pro_save_updates_in_place(pro):
+    from techpourtoutes.forms import ProForm
+    from techpourtoutes.models import Pro
+
+    data = {
+        "civility": pro.civility,
+        "first_name": "Nouveau Prénom",
+        "last_name": pro.last_name,
+        "email": pro.email,
+        "phone": str(pro.phone),
+        "postal_code": "69001",
+        "professional_situation": pro.professional_situation,
+        "job_title": "Nouveau métier",
+        "structure_name": pro.structure_name,
+        "terms_accepted": True,
+    }
+    form = ProForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+    saved = form.save()
+
+    assert saved.pk == pro.pk
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Nouveau Prénom"
+    assert pro.postal_code == "69001"

--- a/techpourtoutes/tests/test_views.py
+++ b/techpourtoutes/tests/test_views.py
@@ -1,8 +1,13 @@
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import override_settings
 from django.urls import reverse
+
+
+def _email_input_is_disabled(html):
+    return bool(re.search(r'id="id_email"[^>]*\bdisabled\b', html))
 
 
 @pytest.mark.django_db
@@ -210,3 +215,139 @@ def test_sponsor_landing_post_invalid_rerenders_with_errors(client, valid_pro_da
     assert response.context["form"].errors
     messages = list(response.context["messages"])
     assert len(messages) > 0
+
+
+# --- Authenticated pro: GET exposes pro in context ---
+
+
+@pytest.mark.django_db
+def test_mentor_landing_get_authenticated_pro_passes_pro_to_context(client, pro):
+    client.force_login(pro)
+    response = client.get(reverse("mentor_landing"))
+    assert response.status_code == 200
+    assert response.context["pro"] == pro
+
+
+@pytest.mark.django_db
+def test_work_ambassador_landing_get_authenticated_pro_passes_pro_to_context(client, pro):
+    client.force_login(pro)
+    response = client.get(reverse("work_ambassador_landing"))
+    assert response.status_code == 200
+    assert response.context["pro"] == pro
+
+
+@pytest.mark.django_db
+def test_workshops_landing_get_authenticated_pro_passes_pro_to_context(client, pro):
+    client.force_login(pro)
+    response = client.get(reverse("workshops_landing"))
+    assert response.status_code == 200
+    assert response.context["pro"] == pro
+
+
+@pytest.mark.django_db
+def test_sponsor_landing_get_authenticated_pro_passes_pro_to_context(client, pro):
+    client.force_login(pro)
+    response = client.get(reverse("sponsor_landing"))
+    assert response.status_code == 200
+    assert response.context["pro"] == pro
+
+
+@pytest.mark.django_db
+def test_mentor_landing_disables_email_for_authenticated_pro(client, pro):
+    client.force_login(pro)
+    html = client.get(reverse("mentor_landing")).content.decode()
+    assert _email_input_is_disabled(html)
+
+
+@pytest.mark.django_db
+def test_mentor_landing_email_editable_for_anonymous(client):
+    html = client.get(reverse("mentor_landing")).content.decode()
+    assert not _email_input_is_disabled(html)
+
+
+@pytest.mark.django_db
+def test_workshops_landing_disables_email_for_authenticated_pro(client, pro):
+    client.force_login(pro)
+    html = client.get(reverse("workshops_landing")).content.decode()
+    assert _email_input_is_disabled(html)
+
+
+@pytest.mark.django_db
+def test_workshops_landing_email_editable_for_anonymous(client):
+    html = client.get(reverse("workshops_landing")).content.decode()
+    assert not _email_input_is_disabled(html)
+
+
+# --- Authenticated pro POST: updates existing pro, does not create a new one ---
+
+
+def _pro_post_data(pro, **overrides):
+    return {
+        "civility": pro.civility,
+        "first_name": pro.first_name,
+        "last_name": pro.last_name,
+        "email": pro.email,
+        "phone": str(pro.phone),
+        "postal_code": pro.postal_code,
+        "professional_situation": pro.professional_situation,
+        "job_title": pro.job_title,
+        "structure_name": pro.structure_name,
+        "terms_accepted": True,
+        **overrides,
+    }
+
+
+@pytest.mark.django_db
+def test_mentor_landing_post_authenticated_pro_updates_pro(client, pro, mock_create_mentor):
+    from techpourtoutes.models import Pro
+
+    client.force_login(pro)
+    client.post(reverse("mentor_landing"), data=_pro_post_data(pro, first_name="Modifiée"))
+
+    assert Pro.objects.count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_work_ambassador_landing_post_authenticated_pro_updates_pro(client, pro):
+    from techpourtoutes.models import Pro
+
+    client.force_login(pro)
+    client.post(
+        reverse("work_ambassador_landing"), data=_pro_post_data(pro, first_name="Modifiée")
+    )
+
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert "work_ambassador" in pro.engagements
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_workshops_landing_post_authenticated_pro_updates_pro(client, pro):
+    from techpourtoutes.models import Pro
+
+    client.force_login(pro)
+    data = _workshop_data(email=pro.email, first_name="Modifiée")
+    with patch("techpourtoutes.views.coalition_views.notify_workshop_request_task"):
+        client.post(reverse("workshops_landing"), data=data)
+
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert "workshops" in pro.engagements
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_sponsor_landing_post_authenticated_pro_updates_pro(client, pro):
+    from techpourtoutes.models import Pro
+
+    client.force_login(pro)
+    client.post(reverse("sponsor_landing"), data=_pro_post_data(pro, first_name="Modifiée"))
+
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert "sponsor" in pro.engagements

--- a/techpourtoutes/tests/test_workshop_form.py
+++ b/techpourtoutes/tests/test_workshop_form.py
@@ -102,3 +102,65 @@ def test_workshop_form_exposes_remark_and_ateliers():
     assert form.is_valid(), form.errors
     assert form.cleaned_data["remark"] == "Une remarque"
     assert form.cleaned_data["ateliers"] == ["future_of_tech", "future_of_ia"]
+
+
+@pytest.mark.django_db
+def test_workshop_form_with_pro_email_is_disabled(pro):
+    from techpourtoutes.forms import WorkshopForm
+
+    form = WorkshopForm(pro=pro)
+    assert form.fields["email"].disabled
+
+
+@pytest.mark.django_db
+def test_workshop_form_with_pro_sets_initial_values(pro):
+    from techpourtoutes.forms import WorkshopForm
+
+    form = WorkshopForm(pro=pro)
+    assert form.initial["email"] == pro.email
+    assert form.initial["first_name"] == pro.first_name
+
+
+@pytest.mark.django_db
+def test_workshop_form_with_pro_terms_not_required(pro):
+    from techpourtoutes.forms import WorkshopForm
+
+    data = valid_data(
+        email=pro.email,
+        # terms_accepted NOT submitted
+    )
+    del data["terms_accepted"]
+    form = WorkshopForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_workshop_form_with_pro_allows_own_email(pro):
+    from techpourtoutes.forms import WorkshopForm
+
+    data = valid_data(email=pro.email)
+    form = WorkshopForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_workshop_form_with_pro_save_updates_in_place(pro):
+    from techpourtoutes.forms import WorkshopForm
+    from techpourtoutes.models import Pro
+
+    data = valid_data(
+        email=pro.email,
+        first_name="Modifiée",
+        structure_name="Nouveau lycée",
+        structure_id="0750002B",
+        postal_code="69001",
+    )
+    form = WorkshopForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+    saved = form.save()
+
+    assert saved.pk == pro.pk
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert pro.structure_name == "Nouveau lycée"

--- a/techpourtoutes/views/coalition_views.py
+++ b/techpourtoutes/views/coalition_views.py
@@ -14,29 +14,27 @@ def coalition_home(request):
 
 
 def mentor_landing(request):
+    pro = request.user.pro if hasattr(request.user, "pro") else None
     if request.method == "POST":
-        form = ProForm(data=request.POST)
+        form = ProForm(data=request.POST, pro=pro)
         if form.is_valid():
             result = CreateMentor(pro=form.save(commit=False))
             if result.failure:
                 for error in result.errors:
                     messages.error(request, error)
-                return render(request, "coalition/mentor_landing.html", {"form": form})
+                return render(request, "coalition/mentor_landing.html", {"form": form, "pro": pro})
             return redirect("coalition_welcome")
         else:
-            messages.error(
-                request,
-                "Des erreurs empêchent la validation du formulaire, "
-                "merci de les corriger et de réessayer à nouveau.",
-            )
+            _render_errors(request, form)
     else:
-        form = ProForm()
-    return render(request, "coalition/mentor_landing.html", {"form": form})
+        form = ProForm(pro=pro)
+    return render(request, "coalition/mentor_landing.html", {"form": form, "pro": pro})
 
 
 def work_ambassador_landing(request):
+    pro = request.user.pro if hasattr(request.user, "pro") else None
     if request.method == "POST":
-        form = ProForm(data=request.POST)
+        form = ProForm(data=request.POST, pro=pro)
         if form.is_valid():
             pro = form.save(commit=False)
             pro.engagements.append("work_ambassador")
@@ -45,14 +43,10 @@ def work_ambassador_landing(request):
             CoalitionMailer.new_pro(pro=pro, engagement="work_ambassador")
             return redirect("coalition_welcome")
         else:
-            messages.error(
-                request,
-                "Des erreurs empêchent la validation du formulaire, "
-                "merci de les corriger et de réessayer à nouveau.",
-            )
+            _render_errors(request, form)
     else:
-        form = ProForm()
-    return render(request, "coalition/work_ambassador_landing.html", {"form": form})
+        form = ProForm(pro=pro)
+    return render(request, "coalition/work_ambassador_landing.html", {"form": form, "pro": pro})
 
 
 def internships_landing(request):
@@ -60,8 +54,9 @@ def internships_landing(request):
 
 
 def workshops_landing(request):
+    pro = request.user.pro if hasattr(request.user, "pro") else None
     if request.method == "POST":
-        form = WorkshopForm(data=request.POST)
+        form = WorkshopForm(data=request.POST, pro=pro)
         if form.is_valid():
             pro = form.save(commit=False)
             pro.engagements.append("workshops")
@@ -76,19 +71,16 @@ def workshops_landing(request):
             CoalitionMailer.welcome(pro=pro, token=pro.issue_login_token())
             return redirect("coalition_welcome")
         else:
-            messages.error(
-                request,
-                "Des erreurs empêchent la validation du formulaire, "
-                "merci de les corriger et de réessayer à nouveau.",
-            )
+            _render_errors(request, form)
     else:
-        form = WorkshopForm()
-    return render(request, "coalition/workshops_landing.html", {"form": form})
+        form = WorkshopForm(pro=pro)
+    return render(request, "coalition/workshops_landing.html", {"form": form, "pro": pro})
 
 
 def sponsor_landing(request):
+    pro = request.user.pro if hasattr(request.user, "pro") else None
     if request.method == "POST":
-        form = ProForm(data=request.POST)
+        form = ProForm(data=request.POST, pro=pro)
         if form.is_valid():
             pro = form.save(commit=False)
             pro.engagements.append("sponsor")
@@ -97,14 +89,10 @@ def sponsor_landing(request):
             CoalitionMailer.new_pro(pro=pro, engagement="sponsor")
             return redirect("coalition_welcome")
         else:
-            messages.error(
-                request,
-                "Des erreurs empêchent la validation du formulaire, "
-                "merci de les corriger et de réessayer à nouveau.",
-            )
+            _render_errors(request, form)
     else:
-        form = ProForm()
-    return render(request, "coalition/sponsor_landing.html", {"form": form})
+        form = ProForm(pro=pro)
+    return render(request, "coalition/sponsor_landing.html", {"form": form, "pro": pro})
 
 
 def search_schools(request):
@@ -120,7 +108,7 @@ def search_schools(request):
             Q(name_normalized__icontains=School.normalize(token))
             | Q(postal_code__startswith=token)
         )
-    schools = schools.order_by("name")
+    schools = schools.order_by("identifier")
 
     SCHOOL_PAGE_SIZE = 20
     start = (page - 1) * SCHOOL_PAGE_SIZE
@@ -136,3 +124,18 @@ def search_schools(request):
 
 def coalition_welcome(request):
     return render(request, "coalition/coalition_welcome.html", {})
+
+
+def _render_errors(request, form):
+    if form.has_error("email", "email_exists"):
+        messages.error(
+            request,
+            "Un compte existe déjà pour cet email, merci de vous connecter "
+            "avant de soumettre votre engagement.",
+        )
+    else:
+        messages.error(
+            request,
+            "Des erreurs empêchent la validation du formulaire, "
+            "merci de les corriger et de réessayer à nouveau.",
+        )

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -1938,9 +1938,6 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
-  .h-20 {
-    height: calc(var(--spacing) * 20);
-  }
   .h-42 {
     height: calc(var(--spacing) * 42);
   }
@@ -1988,9 +1985,6 @@
   }
   .w-15 {
     width: calc(var(--spacing) * 15);
-  }
-  .w-20 {
-    width: calc(var(--spacing) * 20);
   }
   .w-\[250px\] {
     width: 250px;
@@ -2126,17 +2120,8 @@
   .gap-5 {
     gap: calc(var(--spacing) * 5);
   }
-  .gap-8 {
-    gap: calc(var(--spacing) * 8);
-  }
-  .gap-16 {
-    gap: calc(var(--spacing) * 16);
-  }
   .gap-20 {
     gap: calc(var(--spacing) * 20);
-  }
-  .gap-24 {
-    gap: calc(var(--spacing) * 24);
   }
   .gap-x-2 {
     column-gap: calc(var(--spacing) * 2);
@@ -2304,6 +2289,9 @@
   }
   .pb-2 {
     padding-bottom: calc(var(--spacing) * 2);
+  }
+  .pb-3 {
+    padding-bottom: calc(var(--spacing) * 3);
   }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
@@ -2800,17 +2788,6 @@
   .xl\:inline {
     @media (width >= 80rem) {
       display: inline;
-    }
-  }
-  .\[\&\>p\]\:pb-3 {
-    &>p {
-      padding-bottom: calc(var(--spacing) * 3);
-    }
-  }
-  .\[\&\>p\]\:font-medium {
-    &>p {
-      --tw-font-weight: var(--font-weight-medium);
-      font-weight: var(--font-weight-medium);
     }
   }
   .\[body\:has\(\#sidebar-drawer\:checked\)_\&\]\:block {


### PR DESCRIPTION
### Contexte

Jusqu'à présent, les pages d'engagement de la coalition (mentor, mécène, ambassadrice, ateliers) créaient systématiquement un nouveau `Pro` à la soumission. Un utilisateur connecté voyait des champs vides et un utilisateur existant se heurtait à l'erreur `Un compte avec cet email existe déjà`.

Cette PR adapte ces formulaires : 
- au cas où Pro est **déjà authentifié** : ses informations sont pré-remplies, son compte est mis à jour en place, et un nouvel engagement est simplement ajouté à son profil.
- au cas où Pro a déjà l'action d'engagement : le formulaire n'apparaît plus
- au cas où un mail est déjà utilisé, nous invitons plus clairement à se log.

### Changements

**Formulaires (`ProForm`, `WorkshopForm`)**
- Nouveau paramètre `pro` au constructeur : quand il est fourni, le formulaire pré-remplit ses valeurs initiales, **désactive le champ email** et rend les CGU (`terms_accepted`) non obligatoires.
- `clean_email` autorise désormais le Pro à conserver son propre email (plus d'erreur de doublon sur soi-même).
- `save()` met à jour le `Pro` existant **en place** au lieu d'en créer un nouveau lorsque `pro` est présent.

**Vues (`coalition_views.py`)**
- Chaque vue de landing récupère le `Pro` connecté (`request.user.pro`) et le transmet au formulaire et au template.
- Factorisation de la gestion d'erreurs dans `_render_errors`, qui affiche un message spécifique invitant à se connecter lorsque l'email existe déjà.
- hors scope : `search_schools` : tri des résultats par `identifier` plutôt que par `name`.

**Templates**
- Les cartes d'engagement affichent le prénom/nom du Pro connecté et masquent le bouton « Je deviens… » si l'engagement est déjà pris. Pour le cas du mentorat, nous affichons aussi le bouton vers l'espace mentorat dans le cas où l'engagement mentor existe.
- Champ email rendu en variante `disabled` et case CGU masquée pour les Pros connectés.
- `info_card` : ajustement des graisses de police (`font-light` / `font-medium`).