### PR TITLE
Ajout de la page "Pitcher ma formation"

### DIFF
--- a/techpourtoutes/forms/__init__.py
+++ b/techpourtoutes/forms/__init__.py
@@ -1,6 +1,13 @@
 from .account_edit_form import AccountEditForm
 from .login_request_form import LoginRequestForm
 from .pro_form import ProForm
+from .training_ambassador_form import TrainingAmbassadorForm
 from .workshop_form import WorkshopForm
 
-__all__ = ["AccountEditForm", "LoginRequestForm", "ProForm", "WorkshopForm"]
+__all__ = [
+    "AccountEditForm",
+    "LoginRequestForm",
+    "ProForm",
+    "TrainingAmbassadorForm",
+    "WorkshopForm",
+]

--- a/techpourtoutes/forms/pro_form.py
+++ b/techpourtoutes/forms/pro_form.py
@@ -21,7 +21,8 @@ class ProForm(forms.Form):
     )
     professional_situation = forms.ChoiceField(
         label=_("Votre situation professionnelle*"),
-        choices=[("", _("Sélectionner une option")), *Pro.ProfessionalSituation.choices],
+        choices=[("", _("Sélectionner une option"))]
+        + [c for c in Pro.ProfessionalSituation.choices if c[0] != "student"],
     )
     structure_name = forms.CharField(label=_("Nom de votre structure*"), required=False)
     job_title = forms.CharField(label=_("Votre métier*"))
@@ -69,12 +70,11 @@ class ProForm(forms.Form):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
-        if self.pro and email == self.pro.email:
-            return email
-        if User.objects.filter(email=email).exists():
-            raise forms.ValidationError(
-                _("Un compte avec cet email existe déjà."), code="email_exists"
-            )
+        if (
+            not (self.pro and email == self.pro.email)
+            and User.objects.filter(email=email).exists()
+        ):
+            raise forms.ValidationError(_("Un compte avec cet email existe déjà."))
         return email
 
     def save(self, commit=True):

--- a/techpourtoutes/forms/training_ambassador_form.py
+++ b/techpourtoutes/forms/training_ambassador_form.py
@@ -1,23 +1,11 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from phonenumber_field.formfields import PhoneNumberField
 
-from ..models import Pro, User, WorkshopRequest
-
-FONCTION_CHOICES = [
-    ("", _("Sélectionner une option")),
-    ("Enseignante", _("Enseignante")),
-    ("Documentaliste", _("Documentaliste")),
-    ("CPE", _("CPE")),
-    ("Responsable établissement", _("Responsable établissement")),
-    ("Référente mission EDD", _("Référente mission EDD")),
-    ("DRANE / DAN / IAN", _("DRANE / DAN / IAN")),
-    ("Autre mission au sein d'un établissement", _("Autre mission au sein d'un établissement")),
-    ("parent d'élèves", _("Parent d'élève")),
-    ("je ne travaille pas dans un établissement", _("Je ne travaille pas dans un établissement")),
-]
+from ..models import Pro, User
 
 
-class WorkshopForm(forms.Form):
+class TrainingAmbassadorForm(forms.Form):
     civility = forms.ChoiceField(label=_("Votre civilité*"), choices=Pro.Civility.choices)
     first_name = forms.CharField(label=_("Votre prénom*"))
     last_name = forms.CharField(label=_("Votre nom*"))
@@ -25,16 +13,10 @@ class WorkshopForm(forms.Form):
         label=_("Votre email*"),
         error_messages={"invalid": _("Saisissez une adresse mail valide.")},
     )
+    phone = PhoneNumberField(required=False, region="FR", label=_("Votre n° de téléphone"))
     structure_id = forms.CharField(widget=forms.HiddenInput)
     structure_name = forms.CharField(label=_("Établissement*"))
     postal_code = forms.CharField(widget=forms.HiddenInput)
-    job_title = forms.ChoiceField(label=_("Fonction*"), choices=FONCTION_CHOICES)
-    remark = forms.CharField(label=_("Remarque"), required=False, widget=forms.Textarea)
-    ateliers = forms.MultipleChoiceField(
-        label=_("Atelier demandé*"),
-        choices=WorkshopRequest.Type.choices,
-        widget=forms.CheckboxSelectMultiple,
-    )
     terms_accepted = forms.BooleanField(
         label=_(
             "J'accepte la création de mon compte, les conditions d'utilisation et la "
@@ -55,6 +37,7 @@ class WorkshopForm(forms.Form):
                     "first_name": pro.first_name,
                     "last_name": pro.last_name,
                     "email": pro.email,
+                    "phone": pro.phone,
                 },
             )
         super().__init__(*args, **kwargs)
@@ -79,10 +62,11 @@ class WorkshopForm(forms.Form):
             pro.civility = data["civility"]
             pro.first_name = data["first_name"]
             pro.last_name = data["last_name"]
-            pro.professional_situation = Pro.ProfessionalSituation.WORKING
+            pro.phone = data["phone"]
+            pro.professional_situation = Pro.ProfessionalSituation.STUDENT
             pro.structure_name = data["structure_name"]
             pro.structure_id = data["structure_id"]
-            pro.job_title = data["job_title"]
+            pro.job_title = "Étudiante"
             pro.postal_code = data["postal_code"]
         else:
             pro = Pro(
@@ -91,10 +75,11 @@ class WorkshopForm(forms.Form):
                 first_name=data["first_name"],
                 last_name=data["last_name"],
                 email=data["email"],
-                professional_situation=Pro.ProfessionalSituation.WORKING,
+                phone=data["phone"],
+                professional_situation=Pro.ProfessionalSituation.STUDENT,
                 structure_name=data["structure_name"],
                 structure_id=data["structure_id"],
-                job_title=data["job_title"],
+                job_title="Étudiante",
                 postal_code=data["postal_code"],
             )
         if commit:

--- a/techpourtoutes/models/pro.py
+++ b/techpourtoutes/models/pro.py
@@ -20,6 +20,7 @@ class Pro(User):
 
     class ProfessionalSituation(models.TextChoices):
         WORKING = "working", _("En emploi")
+        STUDENT = "student", _("En étude")
         RETIRED = "retired", _("À la retraite")
         JOBLESS = "jobless", _("Sans emploi")
 

--- a/techpourtoutes/templates/coalition/coalition_home.html
+++ b/techpourtoutes/templates/coalition/coalition_home.html
@@ -6,7 +6,7 @@
 
     <c-components.title title="Comment contribuer&nbsp;?" variant="h2-thin" />
     <div class="grid grid-cols-2 md:grid-cols-3 gap-5 w-full">
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103 hover:text-primary-500" href="/mentorer">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103 hover:text-primary-500" href="{% url "mentor_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="mentorer-bold" class="w-15 h-15" />
             </div>
@@ -15,7 +15,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="/accueillir-une-stagiaire">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="{% url "internships_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="accueillir-une-stagiaire-bold" class="w-15 h-15" />
             </div>
@@ -24,7 +24,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="/pitcher-mon-metier">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="{% url "work_ambassador_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="pitcher-mon-metier-bold" class="w-15 h-15" />
             </div>
@@ -33,7 +33,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="{% url "training_ambassador_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="pitcher-ma-formation-bold" class="w-15 h-15" />
             </div>
@@ -42,7 +42,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="/devenir-mecene">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="{% url "sponsor_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="devenir-mecene-bold" class="w-15 h-15" />
             </div>
@@ -51,7 +51,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="/organiser-un-atelier">
+        <c-components.card-shadow class="flex flex-col gap-3 justify-between h-42 md:h-38 text-primary-700 hover:border-primary-500 hover:shadow-primary-500 hover:scale-103" href="{% url "workshops_landing" %}">
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="organiser-un-atelier-bold" class="w-15 h-15" />
             </div>

--- a/techpourtoutes/templates/coalition/training_ambassador_landing.html
+++ b/techpourtoutes/templates/coalition/training_ambassador_landing.html
@@ -1,0 +1,148 @@
+<c-layout.base>
+    <c-components.title icon-name="pitcher-ma-formation-bold" title="Pitcher ma formation" />
+    <div class="flex gap-x-4">
+        <c-components.badge label="1 an" />
+        <c-components.badge label="En présentiel" />
+        <c-components.badge label="À distance" />
+    </div>
+
+    <c-components.card title="Devenez ambassadrice étudiante TechPourToutes">
+        <c-components.text>
+            Vous êtes étudiante et vous souhaitez vous engager concrètement pour l'égalité de genre dans l'enseignement supérieur et le monde professionnel&nbsp;? Devenez ambassadrice étudiante TechPourToutes&nbsp;!
+        </c-components.text>
+    </c-components.card>
+
+    <div class="flex justify-center w-full md:hidden">
+        <c-components.button href="#training-ambassador-card" label="Je deviens ambassadrice" />
+    </div>
+
+    <c-components.card title="Des missions concrètes">
+        <c-components.title title="1. Vous devenez le contact étudiant de référence de votre établissement concernant le programme TechPourToutes" variant="intertitre" class="my-3" />
+        <c-components.list>
+            Vous faites connaître à votre communauté étudiante et aux autres associations le programme TechPourToutes
+            Vous travaillez avec l’équipe des référentes et référents égalité de votre établissement pour intégrer TechPourToutes dans la programmation d’actions prévues lorsque cela est possible sur les questions d’égalité, féminisation, VSS...
+            Vous travaillez conjointement avec l’association étudiante féministe de votre établissement pour penser des actions communes
+            Vous impliquez dans la mesure du possible les partenaires de votre établissement dans les actions d’insertion professionnelle de TechPourToutes
+            Vous co-organisez dans la mesure du possible des conférences au sein de vos établissements avec les responsables de formation, référentes et référents égalité et les conférences d’établissements membres du consortium TechPourToutes dans votre établissement.
+        </c-components.list>
+        <p>
+            <span class="italic">Si vous souhaitez aller plus loin&nbsp;:</span>
+            <br>
+            <c-components.list>
+                Vous pouvez être contactées pour intervenir lors de tables rondes et conférences organisées par TechPourToutes.
+            </c-components.list>
+        </p>
+
+        <c-components.title title="2. Vous échangez avec des lycéennes ou des étudiantes en réorientation" variant="intertitre" class="my-3" />
+        <c-components.list>
+            Vous présentez votre formation dans votre ancien lycée ou ceux alentours à l'invitation d'enseignantes et enseignants
+            Vous échangez avec des lycéennes ou des étudiantes inscrites au programme pour répondre à leurs questions sur la plateforme en ligne TechPourToutes et partagez votre expérience dans les études supérieures
+            Vous représentez votre école et parlez de TechPourToutes lors de salons étudiants
+        </c-components.list>
+        <p>
+            <span class="italic">Si vous souhaitez aller plus loin&nbsp;:</span>
+            <br>
+            <c-components.list>
+                Vous pouvez mentorer une lycéenne via notre programme de mentorat qui vous accompagnera dans ce nouveau rôle
+                Vous pouvez vous former et animer des ateliers de découverte des filières et de sensibilisation auprès de lycéennes et collégiennes
+            </c-components.list>
+        </p>
+
+        <c-components.title title="3. Vous participez à un réseau étudiant engagé" variant="intertitre" class="mt-3" />
+        <c-components.text>
+            Vous participez à des événements ambassadrices TechPourToutes, l'occasion de rencontrer d'autres étudiantes engagées et les partenaires du programme.
+
+            Pour toutes ces démarches, notre équipe est là pour vous aider et mettre à votre disposition différents supports de communication.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="Un engagement qui a du sens...">
+        <c-components.text>
+            L'objectif ? La parité dans les métiers techniques du numérique !
+
+            Aujourd'hui, 67 % des femmes ne se sentent pas légitimes de faire des études en informatique, entre autre car elles manquent de représentations féminines et car elles sont deux fois moins nombreuses à être encouragées par leurs parents à travailler dans le numérique que les garçons. Vous qui avez fait ce choix, vous êtes les mieux placées pour encourager plus de filles à changer la façon dont le numérique est fait.
+        </c-components.text>
+    </c-components.card>
+
+    <c-components.card title="...et que vous pourrez valoriser dans votre parcours">
+        <c-components.text>
+            Être ambassadrice TechPourToutes, c'est développer des compétences clés pour la suite de votre parcours&nbsp;:
+        </c-components.text>
+        <c-components.list>
+            Prise de parole en public
+            Travail en équipe
+            Mobilisation de communauté
+            Esprit d'initiative
+            Pédagogie et transmission
+            Sens de l'engagement
+        </c-components.list>
+    </c-components.card>
+
+    <c-components.accordion title="Cette action est menée par">
+        <c-components.text>
+            la Conférence des Grandes Écoles, France Université et la Conférence des Directeurs des Écoles Françaises d'Ingénieurs.
+
+        </c-components.text>
+        <c-components.button href="{% url "qui_sommes_nous" %}" label="Découvrir tous les membres du consortium TechPourToutes" variant="quaternaly" />
+    </c-components.accordion>
+
+    <c-slot name="right">
+        <div class="flex flex-col items-center px-4 md:mt-[65px] md:self-start"
+             x-data="{ showForm: {{ form.is_bound|yesno:'true,false' }} }"
+             :class="{ 'md:sticky md:top-14 xl:top-8': !showForm }">
+            <c-components.title title="Rejoignez la coalition&nbsp;!" class="justify-center w-[300px] h-16" variant="h3" />
+            <div id="training-ambassador-card">
+                <div x-show="!showForm" {% if not pro or "training_ambassador" not in pro.engagements %}@click.prevent="showForm = true; $nextTick(() => { $refs.formCard.scrollIntoView({ behavior: 'smooth', block: 'start' }) })" class="cursor-pointer"{% endif %}>
+                    <c-components.card-shadow id="training-ambassador-member-card" class="w-[320px] my-5">
+                        <div class="flex gap-5">
+                            <c-components.icon name="badge-coeur" class="shrink-0 w-15 h-15" />
+                            <div>
+                                {% if pro %}
+                                    <p class="font-medium pb-3">{{ pro.first_name }}</p>
+                                    <p class="font-medium pb-3">{{ pro.last_name }}</p>
+                                {% else %}
+                                    <p class="font-light pb-3">Prénom</p>
+                                    <p class="font-light pb-3">Nom</p>
+                                {% endif %}
+                                <p class="font-medium">Ambassadrice TechPourToutes</p>
+                            </div>
+                        </div>
+                        {% if not pro or "training_ambassador" not in pro.engagements %}
+                            <div class="flex justify-center mt-3">
+                                <c-components.button href="" label="Je deviens ambassadrice" />
+                            </div>
+                        {% endif %}
+                    </c-components.card-shadow>
+                </div>
+                <div x-ref="formCard" x-show="showForm" x-cloak
+                    x-transition:enter="transition ease-out duration-300 origin-top"
+                    x-transition:enter-start="scale-y-20"
+                    x-transition:enter-end="scale-y-100"
+                />
+                    <c-components.card-shadow id="training-ambassador-form-card" class="w-[320px] my-5 p-5 relative">
+                        <c-components.icon name="badge-coeur" class="shrink-0 w-15 h-15 absolute -top-5 -right-5" />
+                        <c-patterns.form url="{% url 'training_ambassador_landing' %}">
+                            <c-components.title title="Engagement ambassadrice" variant="h3" />
+                            <p class="description-text-xxs">Les champs suivis d'un astérisque (*) sont obligatoires.</p>
+                            <c-components.form_fields.radio field=form.civility />
+                            <c-components.form_fields.input field=form.first_name autocomplete="given-name" />
+                            <c-components.form_fields.input field=form.last_name autocomplete="family-name" />
+                            <c-components.form_fields.input field=form.email autocomplete="email" variant="{% if pro %}disabled{% endif %}" />
+                            <c-components.form_fields.input field=form.phone autocomplete="tel" />
+                            <c-components.form_fields.school_search
+                                name_field=form.structure_name
+                                id_field=form.structure_id
+                                postal_field=form.postal_code
+                                description="Recherchez par nom et/ou code postal"
+                            />
+                            {% if not pro %}<c-components.form_fields.checkbox field=form.terms_accepted />{% endif %}
+                            <div class="flex justify-center">
+                                <c-components.button type="submit" label="Je deviens ambassadrice" />
+                            </div>
+                        </c-patterns.form>
+                    </c-components.card-shadow>
+                </div>
+            </div>
+        </div>
+    </c-slot>
+</c-layout.base>

--- a/techpourtoutes/tests/test_training_ambassador_form.py
+++ b/techpourtoutes/tests/test_training_ambassador_form.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+def valid_data(**overrides):
+    return {
+        "civility": "Madame",
+        "first_name": "Manon",
+        "last_name": "Desbordes",
+        "email": "manon@example.com",
+        "phone": "0612345678",
+        "structure_id": "0750001A",
+        "structure_name": "Université Paris-Saclay",
+        "postal_code": "75011",
+        "terms_accepted": True,
+        **overrides,
+    }
+
+
+@pytest.mark.django_db
+def test_training_ambassador_form_valid():
+    from techpourtoutes.forms import TrainingAmbassadorForm
+
+    form = TrainingAmbassadorForm(data=valid_data())
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_training_ambassador_form_save_creates_student_pro():
+    from techpourtoutes.forms import TrainingAmbassadorForm
+    from techpourtoutes.models import Pro
+
+    form = TrainingAmbassadorForm(data=valid_data())
+    assert form.is_valid(), form.errors
+    pro = form.save()
+
+    saved = Pro.objects.get(email="manon@example.com")
+    assert saved.pk == pro.pk
+    assert saved.professional_situation == "student"
+    assert saved.job_title == "Étudiante"
+    assert saved.structure_name == "Université Paris-Saclay"
+    assert saved.structure_id == "0750001A"
+    assert saved.postal_code == "75011"
+
+
+@pytest.mark.django_db
+def test_training_ambassador_form_with_pro_save_updates_in_place(pro):
+    from techpourtoutes.forms import TrainingAmbassadorForm
+    from techpourtoutes.models import Pro
+
+    data = valid_data(
+        email=pro.email,
+        first_name="Modifiée",
+        structure_name="Nouvelle université",
+        structure_id="0750002B",
+        postal_code="69001",
+    )
+    form = TrainingAmbassadorForm(data=data, pro=pro)
+    assert form.is_valid(), form.errors
+    saved = form.save()
+
+    assert saved.pk == pro.pk
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert pro.structure_name == "Nouvelle université"
+    assert pro.professional_situation == "student"
+    assert pro.job_title == "Étudiante"
+
+
+@pytest.mark.django_db
+def test_training_ambassador_form_does_not_prefill_structure_name(pro):
+    from techpourtoutes.forms import TrainingAmbassadorForm
+
+    form = TrainingAmbassadorForm(pro=pro)
+    assert not form.initial.get("structure_name")

--- a/techpourtoutes/tests/test_views.py
+++ b/techpourtoutes/tests/test_views.py
@@ -120,6 +120,76 @@ def test_work_ambassador_landing_post_invalid_rerenders_with_errors(client, vali
     assert len(messages) > 0
 
 
+def _training_ambassador_data(**overrides):
+    return {
+        "civility": "Madame",
+        "first_name": "Manon",
+        "last_name": "Desbordes",
+        "email": "manon@example.com",
+        "phone": "0612345678",
+        "structure_id": "0750001A",
+        "structure_name": "Université Paris-Saclay",
+        "postal_code": "75011",
+        "terms_accepted": True,
+        **overrides,
+    }
+
+
+@pytest.mark.django_db
+def test_training_ambassador_landing_get(client):
+    assert client.get(reverse("training_ambassador_landing")).status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_training_ambassador_landing_post_valid_redirects(client):
+    response = client.post(
+        reverse("training_ambassador_landing"), data=_training_ambassador_data()
+    )
+    assert response.status_code == 302
+    assert response["Location"] == reverse("coalition_welcome")
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_training_ambassador_landing_post_valid_persists_student_pro(client):
+    from techpourtoutes.models import Pro
+
+    client.post(reverse("training_ambassador_landing"), data=_training_ambassador_data())
+
+    pro = Pro.objects.get(email="manon@example.com")
+    assert "training_ambassador" in pro.engagements
+    assert pro.professional_situation == "student"
+    assert pro.job_title == "Étudiante"
+
+
+@pytest.mark.django_db
+def test_training_ambassador_landing_get_authenticated_pro_does_not_prefill_structure_name(
+    client, pro
+):
+    client.force_login(pro)
+    response = client.get(reverse("training_ambassador_landing"))
+    assert response.status_code == 200
+    assert not response.context["form"].initial.get("structure_name")
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_training_ambassador_landing_post_authenticated_pro_updates_pro(client, pro):
+    from techpourtoutes.models import Pro
+
+    client.force_login(pro)
+    client.post(
+        reverse("training_ambassador_landing"),
+        data=_training_ambassador_data(email=pro.email, first_name="Modifiée"),
+    )
+
+    assert Pro.objects.count() == 1
+    pro.refresh_from_db()
+    assert pro.first_name == "Modifiée"
+    assert "training_ambassador" in pro.engagements
+
+
 def _workshop_data(**overrides):
     return {
         "civility": "Madame",

--- a/techpourtoutes/urls.py
+++ b/techpourtoutes/urls.py
@@ -8,6 +8,11 @@ urlpatterns = [
     path("coalition/", views.coalition_home, name="coalition_home"),
     path("mentorer/", views.mentor_landing, name="mentor_landing"),
     path("pitcher-mon-metier/", views.work_ambassador_landing, name="work_ambassador_landing"),
+    path(
+        "pitcher-ma-formation/",
+        views.training_ambassador_landing,
+        name="training_ambassador_landing",
+    ),
     path("accueillir-une-stagiaire/", views.internships_landing, name="internships_landing"),
     path("devenir-mecene", views.sponsor_landing, name="sponsor_landing"),
     path("organiser-un-atelier", views.workshops_landing, name="workshops_landing"),

--- a/techpourtoutes/views/__init__.py
+++ b/techpourtoutes/views/__init__.py
@@ -15,6 +15,7 @@ from .coalition_views import (
     mentor_landing,
     search_schools,
     sponsor_landing,
+    training_ambassador_landing,
     work_ambassador_landing,
     workshops_landing,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "schema_pluriannuel",
     "search_schools",
     "sponsor_landing",
+    "training_ambassador_landing",
     "work_ambassador_landing",
     "workshops_landing",
 ]

--- a/techpourtoutes/views/coalition_views.py
+++ b/techpourtoutes/views/coalition_views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.db.models import Q
 from django.shortcuts import redirect, render
 
-from ..forms import ProForm, WorkshopForm
+from ..forms import ProForm, TrainingAmbassadorForm, WorkshopForm
 from ..mailers import CoalitionMailer
 from ..models import School, WorkshopRequest
 from ..services.create_mentor import CreateMentor
@@ -47,6 +47,26 @@ def work_ambassador_landing(request):
     else:
         form = ProForm(pro=pro)
     return render(request, "coalition/work_ambassador_landing.html", {"form": form, "pro": pro})
+
+
+def training_ambassador_landing(request):
+    pro = request.user.pro if hasattr(request.user, "pro") else None
+    if request.method == "POST":
+        form = TrainingAmbassadorForm(data=request.POST, pro=pro)
+        if form.is_valid():
+            pro = form.save(commit=False)
+            pro.engagements.append("training_ambassador")
+            pro.save()
+            CoalitionMailer.welcome(pro=pro, token=pro.issue_login_token())
+            CoalitionMailer.new_pro(pro=pro, engagement="training_ambassador")
+            return redirect("coalition_welcome")
+        else:
+            _render_errors(request, form)
+    else:
+        form = TrainingAmbassadorForm(pro=pro)
+    return render(
+        request, "coalition/training_ambassador_landing.html", {"form": form, "pro": pro}
+    )
 
 
 def internships_landing(request):

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -2034,12 +2034,6 @@
   .origin-top {
     transform-origin: top;
   }
-  .scale-50 {
-    --tw-scale-x: 50%;
-    --tw-scale-y: 50%;
-    --tw-scale-z: 50%;
-    scale: var(--tw-scale-x) var(--tw-scale-y);
-  }
   .scale-y-20 {
     --tw-scale-y: 20%;
     scale: var(--tw-scale-x) var(--tw-scale-y);
@@ -2077,9 +2071,6 @@
   }
   .cursor-pointer {
     cursor: pointer;
-  }
-  .cursor-zoom-in {
-    cursor: zoom-in;
   }
   .resize {
     resize: both;
@@ -2446,6 +2437,9 @@
   .text-white {
     color: var(--color-white);
   }
+  .italic {
+    font-style: italic;
+  }
   .link-hover {
     @layer daisyui.l1.l2 {
       text-decoration-line: none;
@@ -2534,62 +2528,12 @@
       background-color: var(--color-primary-700);
     }
   }
-  .hover\:scale-50 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-scale-x: 50%;
-        --tw-scale-y: 50%;
-        --tw-scale-z: 50%;
-        scale: var(--tw-scale-x) var(--tw-scale-y);
-      }
-    }
-  }
-  .hover\:scale-101 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-scale-x: 101%;
-        --tw-scale-y: 101%;
-        --tw-scale-z: 101%;
-        scale: var(--tw-scale-x) var(--tw-scale-y);
-      }
-    }
-  }
-  .hover\:scale-102 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-scale-x: 102%;
-        --tw-scale-y: 102%;
-        --tw-scale-z: 102%;
-        scale: var(--tw-scale-x) var(--tw-scale-y);
-      }
-    }
-  }
   .hover\:scale-103 {
     &:hover {
       @media (hover: hover) {
         --tw-scale-x: 103%;
         --tw-scale-y: 103%;
         --tw-scale-z: 103%;
-        scale: var(--tw-scale-x) var(--tw-scale-y);
-      }
-    }
-  }
-  .hover\:scale-110 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-scale-x: 110%;
-        --tw-scale-y: 110%;
-        --tw-scale-z: 110%;
-        scale: var(--tw-scale-x) var(--tw-scale-y);
-      }
-    }
-  }
-  .hover\:scale-120 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-scale-x: 120%;
-        --tw-scale-y: 120%;
-        --tw-scale-z: 120%;
         scale: var(--tw-scale-x) var(--tw-scale-y);
       }
     }

--- a/ui/templates/cotton/layout/partials/sidebar.html
+++ b/ui/templates/cotton/layout/partials/sidebar.html
@@ -9,7 +9,7 @@
             <c-components.nav-link href="{% url "mentor_landing" %}" icon="mentorer-light" icon-active="mentorer-bold" label="Mentorer" />
             <c-components.nav-link href="{% url "internships_landing" %}" icon="accueillir-une-stagiaire-light" icon-active="accueillir-une-stagiaire-bold" label="Accueillir une stagiaire" />
             <c-components.nav-link href="{% url "work_ambassador_landing" %}" icon="pitcher-mon-metier-light" icon-active="pitcher-mon-metier-bold" label="Pitcher mon métier" />
-            <c-components.nav-link href="#" icon="pitcher-ma-formation-light" icon-active="pitcher-ma-formation-bold" label="Pitcher ma formation" disabled="true" />
+            <c-components.nav-link href="{% url "training_ambassador_landing" %}" icon="pitcher-ma-formation-light" icon-active="pitcher-ma-formation-bold" label="Pitcher ma formation" />
         </c-components.nav-section>
 
         <c-components.nav-section label="Soutenir la coalition">


### PR DESCRIPTION
Cette PR ajoute la page `Pitcher ma formation`

D'un point de vue technique, rien de notable, à part un formulaire `TrainingAmbassadorForm` sur le modèle des formulaires existants.

Les établissements sont pour l'instant peuplés par la liste des collèges/lycées ; elle sera remplacé dans une prochaine PR par la liste (correcte) des établissements du supérieur.