### PR TITLE
Responsive fixes

### DIFF
--- a/techpourtoutes/templates/coalition/internships_landing.html
+++ b/techpourtoutes/templates/coalition/internships_landing.html
@@ -1,6 +1,6 @@
 <c-layout.base>
     <c-components.title icon-name="accueillir-une-stagiaire-bold" title="Accueillir une stagiaire" />
-    <div class="flex gap-x-4">
+    <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="2 semaines" />
         <c-components.badge label="En présentiel" />
     </div>

--- a/techpourtoutes/templates/coalition/mentor_landing.html
+++ b/techpourtoutes/templates/coalition/mentor_landing.html
@@ -1,6 +1,6 @@
 <c-layout.base>
     <c-components.title icon-name="mentorer-bold" title="Mentorer" />
-    <div class="flex gap-x-4">
+    <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="2 heures / mois" />
         <c-components.badge label="6 mois" />
     </div>

--- a/techpourtoutes/templates/coalition/sponsor_landing.html
+++ b/techpourtoutes/templates/coalition/sponsor_landing.html
@@ -34,16 +34,16 @@
     </c-components.card>
 
     <c-components.title title="Les mécènes du programme" variant="h2" />
-    <div class="flex justify-between w-full gap-x-10 mb-5 text-center">
-        <c-components.card-shadow>
+    <div class="grid grid-cols-3 w-full gap-5 lg:gap-15 mb-5 text-center">
+        <c-components.card-shadow class="flex flex-col items-center">
             <c-components.icon name="logo-la-poste" variant="png" class="h-25 w-25 object-contain" />
             La Poste
         </c-components.card-shadow>
-        <c-components.card-shadow>
+        <c-components.card-shadow class="flex flex-col items-center">
             <c-components.icon name="logo-accenture" variant="png" class="h-25 w-25 object-contain" />
             Accenture
         </c-components.card-shadow>
-        <c-components.card-shadow>
+        <c-components.card-shadow class="flex flex-col items-center">
             <c-components.icon name="logo-dusens" variant="png" class="h-25 w-25 object-contain" />
             Dusens
         </c-components.card-shadow>

--- a/techpourtoutes/templates/coalition/training_ambassador_landing.html
+++ b/techpourtoutes/templates/coalition/training_ambassador_landing.html
@@ -1,6 +1,6 @@
 <c-layout.base>
     <c-components.title icon-name="pitcher-ma-formation-bold" title="Pitcher ma formation" />
-    <div class="flex gap-x-4">
+    <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="1 an" />
         <c-components.badge label="En présentiel" />
         <c-components.badge label="À distance" />

--- a/techpourtoutes/templates/coalition/work_ambassador_landing.html
+++ b/techpourtoutes/templates/coalition/work_ambassador_landing.html
@@ -1,6 +1,6 @@
 <c-layout.base>
     <c-components.title icon-name="pitcher-mon-metier-bold" title="Pitcher mon métier" />
-    <div class="flex gap-x-4">
+    <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="Ponctuel" />
         <c-components.badge label="30 minutes" />
         <c-components.badge label="À distance" />

--- a/techpourtoutes/templates/coalition/workshops_landing.html
+++ b/techpourtoutes/templates/coalition/workshops_landing.html
@@ -1,6 +1,6 @@
 <c-layout.base>
     <c-components.title icon-name="organiser-un-atelier-bold" title="Organiser un atelier" />
-    <div class="flex gap-x-4">
+    <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="Ponctuel" />
         <c-components.badge label="2 heures" />
         <c-components.badge label="En présentiel" />
@@ -16,8 +16,8 @@
         </c-components.text>
     </c-components.card>
 
-    <div class="flex gap-x-5 justify-between max-w-2xl mb">
-        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between h-60">
+    <div class="grid grid-cols-2 w-full gap-5 lg:gap-10 justify-between max-w-2xl mb">
+        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between">
             <c-components.title title="L'enquête TechPourToutes" variant="intertitre" class="text-center" />
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="atelier-latitudes-tech-pour-toutes" variant="png" class="max-w-30 max-h-25" />
@@ -27,7 +27,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between h-60">
+        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between">
             <c-components.title title="Future of Tech" variant="intertitre" class="text-center" />
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="atelier-latitudes-future-of-tech" variant="png" class="max-w-30 max-h-25" />
@@ -36,10 +36,8 @@
                 Découvrir les métiers du numérique et ses impacts sociaux et environnementaux
             </p>
         </c-components.card-shadow>
-    </div>
 
-    <div class="flex gap-x-5 justify-between max-w-2xl">
-        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between h-60">
+        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between">
             <c-components.title title="Future of IA" variant="intertitre" class="text-center" />
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="atelier-latitudes-future-of-ia" variant="png" class="max-w-30 max-h-25" />
@@ -49,7 +47,7 @@
             </p>
         </c-components.card-shadow>
 
-        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between h-60">
+        <c-components.card-shadow variant="blue" class="flex flex-1 flex-col gap-3 justify-between">
             <c-components.title title="Future of Cyber" variant="intertitre" class="text-center" />
             <div class="flex flex-1 justify-center">
                 <c-components.icon name="atelier-latitudes-future-of-cyber" variant="png" class="max-w-30 max-h-25" />

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -2008,9 +2008,6 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
-  .h-22 {
-    height: calc(var(--spacing) * 22);
-  }
   .h-25 {
     height: calc(var(--spacing) * 25);
   }
@@ -2020,8 +2017,8 @@
   .h-60 {
     height: calc(var(--spacing) * 60);
   }
-  .h-auto {
-    height: auto;
+  .h-dvh {
+    height: 100dvh;
   }
   .h-full {
     height: 100%;
@@ -2064,9 +2061,6 @@
   }
   .w-15 {
     width: calc(var(--spacing) * 15);
-  }
-  .w-22 {
-    width: calc(var(--spacing) * 22);
   }
   .w-25 {
     width: calc(var(--spacing) * 25);
@@ -2115,6 +2109,9 @@
   }
   .flex-1 {
     flex: 1;
+  }
+  .flex-auto {
+    flex: auto;
   }
   .shrink-0 {
     flex-shrink: 0;
@@ -2166,8 +2163,14 @@
   .list-disc {
     list-style-type: disc;
   }
+  .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
   .grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .flex-col {
     flex-direction: column;
@@ -2222,9 +2225,6 @@
   }
   .gap-x-5 {
     column-gap: calc(var(--spacing) * 5);
-  }
-  .gap-x-10 {
-    column-gap: calc(var(--spacing) * 10);
   }
   .gap-y-2 {
     row-gap: calc(var(--spacing) * 2);
@@ -2348,9 +2348,6 @@
   .object-contain {
     object-fit: contain;
   }
-  .object-cover {
-    object-fit: cover;
-  }
   .p-1 {
     padding: calc(var(--spacing) * 1);
   }
@@ -2386,6 +2383,15 @@
   }
   .pt-4 {
     padding-top: calc(var(--spacing) * 4);
+  }
+  .pt-10 {
+    padding-top: calc(var(--spacing) * 10);
+  }
+  .pt-12 {
+    padding-top: calc(var(--spacing) * 12);
+  }
+  .pt-14 {
+    padding-top: calc(var(--spacing) * 14);
   }
   .pb-2 {
     padding-bottom: calc(var(--spacing) * 2);
@@ -2513,6 +2519,9 @@
   }
   .text-\[\#ff00ff\] {
     color: #ff00ff;
+  }
+  .text-accent-500 {
+    color: var(--color-accent-500);
   }
   .text-black {
     color: var(--color-black);
@@ -2771,6 +2780,26 @@
       color: var(--color-neutral-0);
     }
   }
+  .sm\:w-full {
+    @media (width >= 40rem) {
+      width: 100%;
+    }
+  }
+  .sm\:grid-cols-2 {
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .sm\:grid-cols-3 {
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .sm\:gap-10 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 10);
+    }
+  }
   .md\:sticky {
     @media (width >= 48rem) {
       position: sticky;
@@ -2784,6 +2813,16 @@
   .md\:mt-\[65px\] {
     @media (width >= 48rem) {
       margin-top: 65px;
+    }
+  }
+  .md\:block {
+    @media (width >= 48rem) {
+      display: block;
+    }
+  }
+  .md\:flex {
+    @media (width >= 48rem) {
+      display: flex;
     }
   }
   .md\:hidden {
@@ -2801,6 +2840,21 @@
       min-width: 560px;
     }
   }
+  .md\:flex-1 {
+    @media (width >= 48rem) {
+      flex: 1;
+    }
+  }
+  .md\:flex-auto {
+    @media (width >= 48rem) {
+      flex: auto;
+    }
+  }
+  .md\:flex-none {
+    @media (width >= 48rem) {
+      flex: none;
+    }
+  }
   .md\:grid-cols-3 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -2814,6 +2868,21 @@
   .md\:justify-around {
     @media (width >= 48rem) {
       justify-content: space-around;
+    }
+  }
+  .md\:gap-4 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 4);
+    }
+  }
+  .md\:gap-10 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 10);
+    }
+  }
+  .md\:gap-15 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 15);
     }
   }
   .md\:self-start {
@@ -2846,6 +2915,16 @@
   .md\:px-32 {
     @media (width >= 48rem) {
       padding-inline: calc(var(--spacing) * 32);
+    }
+  }
+  .lg\:gap-10 {
+    @media (width >= 64rem) {
+      gap: calc(var(--spacing) * 10);
+    }
+  }
+  .lg\:gap-15 {
+    @media (width >= 64rem) {
+      gap: calc(var(--spacing) * 15);
     }
   }
   .xl\:drawer-open {
@@ -2914,6 +2993,16 @@
   .xl\:inline {
     @media (width >= 80rem) {
       display: inline;
+    }
+  }
+  .xl\:w-\[264px\] {
+    @media (width >= 80rem) {
+      width: 264px;
+    }
+  }
+  .xl\:pt-3 {
+    @media (width >= 80rem) {
+      padding-top: calc(var(--spacing) * 3);
     }
   }
   .\[body\:has\(\#sidebar-drawer\:checked\)_\&\]\:block {

--- a/ui/templates/cotton/components/badge.html
+++ b/ui/templates/cotton/components/badge.html
@@ -1,5 +1,5 @@
-<div class="flex py-2 px-6 bg-accent-50 rounded-full border border-accent-500">
-    <div class="text-[#ff00ff] text-[15px] leading-[1.2] relative">
+<div class="flex justify-center items-center py-2 px-6 bg-accent-50 rounded-full border border-accent-500">
+    <div class="text-accent-500 text-[15px] leading-[1.2] relative text-center">
         {% if slot %}{{ slot }}{% else %}{{ label }}{% endif %}
     </div>
 </div>

--- a/ui/templates/cotton/layout/a_propos.html
+++ b/ui/templates/cotton/layout/a_propos.html
@@ -2,11 +2,11 @@
     <c-components.title title="À propos" />
 
     <div class="w-full mt-5">
-        <c-components.tabs>
-            <c-components.tab_link href="{% url 'notre_manifeste' %}" label="Notre manifeste" />
-            <c-components.tab_link href="{% url 'qui_sommes_nous' %}" label="Qui sommes-nous&nbsp;?" />
-            <c-components.tab_link href="{% url 'pourquoi_nous_ecrivons_au_feminin' %}" label="Pourquoi nous écrivons au féminin" />
-            <c-components.tab_link href="{% url 'contact' %}" label="Contact" />
+        <c-components.tabs class="flex">
+            <c-components.tab_link href="{% url 'notre_manifeste' %}" label="Notre manifeste" class="md:flex-none flex-auto" />
+            <c-components.tab_link href="{% url 'qui_sommes_nous' %}" label="Qui sommes-nous&nbsp;?" class="md:flex-none flex-auto" />
+            <c-components.tab_link href="{% url 'pourquoi_nous_ecrivons_au_feminin' %}" label="Pourquoi nous écrivons au féminin" class="md:flex-none flex-auto" />
+            <c-components.tab_link href="{% url 'contact' %}" label="Contact" class="md:flex-none flex-auto" />
         </c-components.tabs>
         <c-components.card class="relative -mt-0.5 rounded-tl-none w-full z-10">
             {{ slot }}

--- a/ui/templates/cotton/layout/partials/sidebar.html
+++ b/ui/templates/cotton/layout/partials/sidebar.html
@@ -1,6 +1,6 @@
 {% load static %}
-<aside class="sticky top-0 h-screen w-[264px] bg-neutral-0 md:border-r-2 md:border-primary-500 md:rounded-r-lg flex flex-col">
-    <div class="flex-1 min-h-0 overflow-y-auto p-3">
+<aside class="sticky top-0 h-dvh w-[264px] bg-neutral-0 md:border-r-2 md:border-primary-500 md:rounded-r-lg flex flex-col">
+    <div class="flex-1 min-h-0 overflow-y-auto px-3 pt-12 xl:pt-3">
         <div class="pb-2 mb-6">
             <c-components.brand-mark class="hidden xl:inline" />
         </div>
@@ -29,7 +29,7 @@
             <c-components.nav-link href="{% url "login_request" %}" label="Se connecter" icon-active="mon-compte-bold" icon="mon-compte-light" />
         {% endif %}
             <c-components.nav-link href="{% url "a_propos" %}" label="À propos" active="{% if request.resolver_match.url_name in 'a_propos notre_manifeste qui_sommes_nous pourquoi_nous_ecrivons_au_feminin contact' %}true{% endif %}" />
-        <c-components.button href="/" label="Découvrir le programme" variant="secondary" />
+        <c-components.button href="https://www.techpourtoutes.io/" label="Découvrir le programme" variant="secondary" />
         </ul>
         <div class="flex items-center justify-between">
             <img src="{% static 'svg/rf.svg' %}"


### PR DESCRIPTION
Cette PR résoud plusieurs petits problèmes détectés au format mobile : 
- la hauteur du menu déroulé était mal géré (bas du menu non fixé, haut du menu légèrement caché)
- les cartes avec images pour les pages `Mécène` et `Organiser un atelier` n'étaient pas parfaitement responsive (des textes pour les ateliers débordaient ; les cartes de mécènes n'avaient plus toutes la même taille)
- les badges roses en haut de page pouvaient dépasser la largeur de la page et le texte à l'intérieur passait sur 2 lignes
- la barre "d'onglets" de la rubrique `À propos` devenait chaotique sur mobile ; elles occupent désormais tout l'espace disponible pour un rendu plus esthétique

Tous ces cas sont désormais gérés correctement