### PR TITLE
Ajout de Matomo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ N8N_WORKSHOP_WEBHOOK_BASIC_AUTH_PASSWORD=some-password
 REDIS_URL=redis://localhost:6379/0
 CELERY_TASK_ALWAYS_EAGER=True
 
+# Matomo (optionnel — laisser vide pour désactiver le tracking)
+# Valeurs différentes selon l'environnement (staging / prod)
+MATOMO_URL=
+MATOMO_SITE_ID=
+
 # Sentry (optionnel — laisser vide pour désactiver)
 SENTRY_DSN=
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -182,6 +182,10 @@ CELERY_BROKER_URL = env("REDIS_URL", default="redis://localhost:6379/0")
 CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", default=False)
 CELERY_TASK_EAGER_PROPAGATES = True
 
+# Matomo analytics (values differ per environment; leave empty to disable tracking)
+MATOMO_URL = env("MATOMO_URL", default="").rstrip("/")
+MATOMO_SITE_ID = env("MATOMO_SITE_ID", default="")
+
 # Sentry
 SENTRY_DSN = env("SENTRY_DSN", default="")
 if SENTRY_DSN:

--- a/techpourtoutes/templatetags/matomo.py
+++ b/techpourtoutes/templatetags/matomo.py
@@ -1,0 +1,28 @@
+from django import template
+from django.conf import settings
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+SNIPPET = """<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['disableCookies']);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="%(url)s/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '%(site_id)s']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->"""
+
+
+@register.simple_tag
+def matomo_tracking():
+    if not (settings.MATOMO_URL and settings.MATOMO_SITE_ID):
+        return ""
+    return mark_safe(SNIPPET % {"url": settings.MATOMO_URL, "site_id": settings.MATOMO_SITE_ID})

--- a/techpourtoutes/tests/test_matomo_tracking.py
+++ b/techpourtoutes/tests/test_matomo_tracking.py
@@ -1,0 +1,16 @@
+from django.test import override_settings
+from django.urls import reverse
+
+
+@override_settings(MATOMO_URL="https://matomo.example.test", MATOMO_SITE_ID="42")
+def test_matomo_snippet_rendered_when_configured(client):
+    content = client.get(reverse("notre_manifeste")).content.decode()
+    assert 'var u="https://matomo.example.test/"' in content
+    assert "_paq.push(['setSiteId', '42'])" in content
+    assert "_paq.push(['disableCookies'])" in content
+
+
+@override_settings(MATOMO_URL="", MATOMO_SITE_ID="")
+def test_matomo_snippet_absent_when_not_configured(client):
+    content = client.get(reverse("notre_manifeste")).content.decode()
+    assert "matomo" not in content.lower()

--- a/ui/templates/cotton/layout/base.html
+++ b/ui/templates/cotton/layout/base.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-{% load tailwind_cli static %}
+{% load tailwind_cli static matomo %}
 <html data-theme="techpourtoutes">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {% matomo_tracking %}
         <title>TechPourToutes</title>
         <link rel="icon" type="image/png" href="{% static 'images/favicon-tpt.png' %}">
         {% tailwind_css %}


### PR DESCRIPTION
Pour activer le tracking Matomo, configurer les variables d'env `MATOMO_URL` et `MATOMO_SITE_ID` sur Scalingo.