### PR TITLE
Renforcer la sécurité en prod (https / secure cookies)

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -129,6 +129,19 @@ LOGOUT_REDIRECT_URL = "/"
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 90  # 90 days
 SESSION_SAVE_EVERY_REQUEST = True
 
+# Security hardening (production only; local dev and tests run over plain HTTP)
+if not DEBUG:
+    # The platform proxy terminates TLS and forwards plain HTTP with this header, letting
+    # request.is_secure() recognise the original HTTPS request (cookies, redirect, HSTS).
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    # Start conservative; ramp up to 31536000 (1 year) once HTTPS is confirmed stable.
+    SECURE_HSTS_SECONDS = 3600
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+
 # Email
 DEFAULT_FROM_EMAIL = env(
     "DEFAULT_FROM_EMAIL", default="TechPourToutes <noreply@techpourtoutes.io>"

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,13 @@ def use_simple_static_storage(settings):
 
 
 @pytest.fixture(autouse=True)
+def disable_https_redirect(settings):
+    # pytest-django forces DEBUG=False, which activates SECURE_SSL_REDIRECT and would
+    # 301-redirect every test-client request (the test client speaks plain HTTP).
+    settings.SECURE_SSL_REDIRECT = False
+
+
+@pytest.fixture(autouse=True)
 def celery_eager(settings):
     settings.CELERY_TASK_ALWAYS_EAGER = True
     settings.CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
## The context

On a PaaS (Heroku/Scalingo/Clever Cloud–style), the edge proxy owns the certificate, the TLS handshake, renewal, SNI, etc., and then forwards a plain HTTP request to gunicorn over the internal network.

The consequence : from Django's point of view, every request arrives as plain HTTP. So `request.is_secure()` returns False for everything, and Django has no native idea the user's real connection was HTTPS. The only signal is an HTTP header the proxy injects (`X-Forwarded-Proto: https`).

## The changes

### `SECURE_PROXY_SSL_HEADER` — the keystone

Default: None. New value: `("HTTP_X_FORWARDED_PROTO", "https")`.
It tells Django: "if you see this header with this value, treat the request as HTTPS." With it set, `request.is_secure()` returns True again behind the proxy. The other four settings below all depend, directly or indirectly, on is_secure() being correct. 

### `SESSION_COOKIE_SECURE`
Default: False. When True, Django adds the Secure flag to the sessionid cookie, so the browser only ever sends it over HTTPS, never plain HTTP.
Difference it makes here : our auth is passwordless, so the session cookie is the credential. With `SESSION_SAVE_EVERY_REQUEST = True` it's actively refreshed on every request. Without Secure, if a user ever hits http:// (typed the URL, an old bookmark, an emailed link), the browser attaches that long-lived credential to a cleartext request that can be sniffed on the wire (café/airport Wi-Fi, etc.). Secure guarantees the cookie never travels in cleartext.

### `CSRF_COOKIE_SECURE`
Default: False. Same mechanism, applied to the csrftoken cookie.
The CSRF token isn't a login credential, but leaking it over HTTP undermines CSRF protection, so this is defense-in-depth. check --deploy also flags it.

### `SECURE_SSL_REDIRECT`
Default: False. When True, SecurityMiddleware 301-redirects any HTTP request to its HTTPS equivalent — so a user landing on http:// gets bounced to https://.

### `SECURE_HSTS_SECONDS`
Default: 0 (off). When > 0, Django sends a Strict-Transport-Security header telling the browser: "for the next N seconds, always use HTTPS for this domain, and don't let users click through cert warnings."
Difference it makes: after the first visit, the browser itself upgrades any http:// to https:// before a single byte leaves the machine — closing the gap where even the first request of a session could go out in cleartext (which a redirect can't protect, because the cleartext request already left).
Companions: `SECURE_HSTS_INCLUDE_SUBDOMAINS`, `SECURE_HSTS_PRELOAD`
Caveat — HSTS is sticky and hard to undo. If wz set 31536000 (1 year) and later can't serve HTTPS on that domain, browsers will refuse to connect and users are locked out until the max-age expires. [Standard practice](https://docs.djangoproject.com/en/5.1/ref/middleware/#http-strict-transport-security): start small (3600), confirm everything works, then ramp up to a year.