### PR TITLE
correctly escapejs

### DIFF
--- a/techpourtoutes/tests/test_search_schools.py
+++ b/techpourtoutes/tests/test_search_schools.py
@@ -55,6 +55,22 @@ def test_search_schools_empty_query_returns_first_page(client, schools):
 
 
 @pytest.mark.django_db
+def test_school_search_escapes_reflected_value_for_js_context(client):
+    # On a failed POST the form re-renders with the submitted structure_name interpolated
+    # into the Alpine x-data JS strings. escapejs emits ' for a single quote (safe in
+    # the JS context); plain HTML autoescaping would emit &#x27; which the browser decodes
+    # back to a real quote, breaking out of the string.
+    response = client.post(
+        reverse("training_ambassador_landing"),
+        {"structure_name": "Test'X"},
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Test\\u0027X" in content
+    assert "Test&#x27;X" not in content
+
+
+@pytest.mark.django_db
 def test_search_schools_paginates_with_next_page_sentinel(client):
     from techpourtoutes.models import School
 

--- a/ui/templates/cotton/components/form_fields/school_search.html
+++ b/ui/templates/cotton/components/form_fields/school_search.html
@@ -10,10 +10,10 @@
 <c-components.form-fields.base :field=name_field label=label description=description class=class>
     <div x-data="{
             open: false,
-            query: '{{ name_field.value|default:"" }}{% if name_field.value and postal_field.value %} ({{ postal_field.value }}){% endif %}',
-            structureName: '{{ name_field.value|default:"" }}',
-            structureId: '{{ id_field.value|default:"" }}',
-            postalCode: '{{ postal_field.value|default:"" }}',
+            query: '{{ name_field.value|default:""|escapejs }}{% if name_field.value and postal_field.value %} ({{ postal_field.value|escapejs }}){% endif %}',
+            structureName: '{{ name_field.value|default:""|escapejs }}',
+            structureId: '{{ id_field.value|default:""|escapejs }}',
+            postalCode: '{{ postal_field.value|default:""|escapejs }}',
             select(id, name, postal) {
                 this.structureId = id;
                 this.structureName = name;


### PR DESCRIPTION
The `name_field` values of the `school_search` are incorrectly espaced for js.

XSS (cross-site scripting) was theorically possible, even if only self-XSS was possible. 

|escapejs fixes it.