### PR TITLE
Sécuriser admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ SECRET_KEY=some-value
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1
 DATABASE_URL=postgres://username@localhost:5432/techpourtoutes
+ADMIN_URL=admin
 
 # Email (Brevo/Anymail — only needed in production; local uses Mailpit on port 1025)
 # Install: brew install mailpit — run with: mailpit — UI at http://localhost:8025

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Plateforme web Django pour la communauté TechPourToutes.
 - **Ruff** pour le linting et le formatage
 - **Tailwind CSS** + **DaisyUI** (via django-tailwind-cli)
 - **django-cotton** pour les composants UI
+- **django-otp** pour la double authentification (2FA) de l'admin
 
 ## Structure du projet
 
@@ -118,6 +119,20 @@ mailpit
 L'interface est disponible sur [http://localhost:8025](http://localhost:8025). Tous les emails envoyés par l'application y apparaissent.
 
 > En production, les emails sont envoyés via [Brevo](https://www.brevo.com/) (Anymail). La variable `BREVO_API_KEY` doit être renseignée dans le `.env`.
+
+## Admin
+
+Par défaut, l'interface d'administration Django est servie sur `/admin/`. En production, l'url est déterminée par la variable d'environnement `ADMIN_URL` (ex. `ADMIN_URL=mon-chemin-prive`).
+
+### Double authentification (2FA)
+
+En production, l'accès à l'admin exige un second facteur TOTP en plus du mot de passe, via [django-otp](https://github.com/django-otp/django-otp). En local, la 2FA est désactivée : le formulaire de connexion standard suffit. Pour enregistrer un appareil :
+
+```bash
+uv run python manage.py add_totp_device <email>
+```
+
+La commande crée un appareil TOTP confirmé et affiche la clé secrète à saisir manuellement dans l'application d'authentification.
 
 ## Icônes SVG
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -23,6 +23,8 @@ SECRET_KEY = env("SECRET_KEY")
 DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 SITE_URL = env("HOST", default="https://localhost:8000").rstrip("/")
+# Admin is mounted at this path; override in production to a non-guessable value.
+ADMIN_URL = env("ADMIN_URL", default="admin").strip("/")
 DATABASES = {"default": env.db("DATABASE_URL")}
 
 # Application definition
@@ -41,6 +43,8 @@ INSTALLED_APPS = [
     "simple_history",
     "phonenumber_field",
     "anymail",
+    "django_otp",
+    "django_otp.plugins.otp_totp",
     # Apps techpourtoutes
     "techpourtoutes",
     "ui",
@@ -55,6 +59,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -15,11 +15,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("accounts/", include("django.contrib.auth.urls")),
     path("", include("techpourtoutes.urls")),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "django-cotton>=2.6.2",
   "django-environ>=0.13",
   "django-extensions>=4.1",
+  "django-otp>=1.7",
   "django-phonenumber-field>=8.4",
   "django-simple-history>=3.11",
   "django-tailwind-cli>=4.6",

--- a/techpourtoutes/admin.py
+++ b/techpourtoutes/admin.py
@@ -1,6 +1,43 @@
+from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin import AdminSite
+from django_otp.admin import OTPAdminSite
 
 from .models import Pro, User
 
-admin.site.register(User)
-admin.site.register(Pro)
+
+class AdminSiteWith2FA(OTPAdminSite):
+    # Require a verified TOTP device (2FA) for admin access, except in local development (DEBUG),
+    # where the stock login form and permissions apply so no second factor is needed. DEBUG is
+    # read per request because admin autodiscover runs before the test runner forces DEBUG=False.
+    @property
+    def login_form(self):
+        return None if settings.DEBUG else OTPAdminSite.login_form
+
+    @property
+    def login_template(self):
+        return None if settings.DEBUG else OTPAdminSite.login_template
+
+    def has_permission(self, request):
+        if settings.DEBUG:
+            return AdminSite.has_permission(self, request)
+        return super().has_permission(request)
+
+
+admin.site.__class__ = AdminSiteWith2FA
+
+# Credentials and login-token fields must never be exposed through the admin: a password
+# typed here would be stored unhashed
+CREDENTIAL_FIELDS = ("password", "login_token_hash")
+
+
+@admin.register(User)
+class AccountAdmin(admin.ModelAdmin):
+    exclude = CREDENTIAL_FIELDS
+
+
+@admin.register(Pro)
+class ProAdmin(AccountAdmin):
+    # The Jobirl token is a credential; the Jobirl id is set by the API, so show it read-only.
+    exclude = (*CREDENTIAL_FIELDS, "jobirl_user_token")
+    readonly_fields = ("jobirl_user_id",)

--- a/techpourtoutes/management/commands/add_totp_device.py
+++ b/techpourtoutes/management/commands/add_totp_device.py
@@ -1,0 +1,20 @@
+from base64 import b32encode
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+
+class Command(BaseCommand):
+    help = "Create a confirmed TOTP (2FA) device for a user and print its secret key."
+
+    def add_arguments(self, parser):
+        parser.add_argument("email")
+
+    def handle(self, *args, **options):
+        email = options["email"]
+        user = get_user_model().objects.filter(email=email).first()
+        if user is None:
+            raise CommandError(f"No user found with email {email!r}.")
+        device = TOTPDevice.objects.create(user=user, name="default", confirmed=True)
+        self.stdout.write(b32encode(device.bin_key).decode())

--- a/techpourtoutes/management/commands/seed.py
+++ b/techpourtoutes/management/commands/seed.py
@@ -1,4 +1,5 @@
-from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 
 from techpourtoutes.models import Pro
 
@@ -10,6 +11,11 @@ class Command(BaseCommand):
     help = "Seed the database with minimal dev data"
 
     def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError(
+                "seed creates an account with a well-known password and is for local "
+                "development only; it refuses to run with DEBUG=False."
+            )
         self._create_admin_pro()
 
     def _create_admin_pro(self):

--- a/techpourtoutes/tests/test_add_totp_device.py
+++ b/techpourtoutes/tests/test_add_totp_device.py
@@ -1,0 +1,23 @@
+import io
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.django_db
+def test_add_totp_device_creates_confirmed_device_and_prints_secret(pro):
+    from django_otp.plugins.otp_totp.models import TOTPDevice
+
+    out = io.StringIO()
+    call_command("add_totp_device", pro.email, stdout=out)
+
+    device = TOTPDevice.objects.get(user=pro)
+    assert device.confirmed
+    assert out.getvalue().strip()  # the TOTP secret, for manual entry in an authenticator app
+
+
+@pytest.mark.django_db
+def test_add_totp_device_unknown_email_errors():
+    with pytest.raises(CommandError):
+        call_command("add_totp_device", "nobody@example.com")

--- a/techpourtoutes/tests/test_admin.py
+++ b/techpourtoutes/tests/test_admin.py
@@ -1,0 +1,99 @@
+import importlib
+
+import pytest
+from django.test import override_settings
+from django.urls import clear_url_caches, reverse
+
+from techpourtoutes.models import Pro
+
+
+@pytest.mark.django_db
+def test_admin_mounts_at_configured_url(client):
+    import conf.urls
+
+    try:
+        with override_settings(ADMIN_URL="secret-mgmt"):
+            importlib.reload(conf.urls)
+            clear_url_caches()
+            # The configured path resolves (redirects to login); the default does not exist.
+            assert client.get("/secret-mgmt/").status_code != 404
+            assert client.get("/admin/").status_code == 404
+    finally:
+        importlib.reload(conf.urls)
+        clear_url_caches()
+
+
+@pytest.fixture
+def admin_pro(db):
+    pro = Pro(
+        username="admin@example.com",
+        civility=Pro.Civility.MADAME,
+        first_name="Admin",
+        last_name="Martin",
+        email="admin@example.com",
+        phone="+33612345678",
+        postal_code="75001",
+        professional_situation=Pro.ProfessionalSituation.WORKING,
+        job_title="Admin",
+        structure_name="Inria",
+        is_staff=True,
+        is_superuser=True,
+    )
+    pro.save()
+    pro.set_password("initial-pass")
+    pro.save(update_fields=["password"])
+    return pro
+
+
+@pytest.fixture
+def verified_admin_client(client, admin_pro):
+    from django_otp import DEVICE_ID_SESSION_KEY
+    from django_otp.plugins.otp_totp.models import TOTPDevice
+
+    device = TOTPDevice.objects.create(user=admin_pro, name="default", confirmed=True)
+    client.force_login(admin_pro)
+    session = client.session
+    session[DEVICE_ID_SESSION_KEY] = device.persistent_id
+    session.save()
+    return client
+
+
+@pytest.mark.django_db
+def test_admin_requires_verified_otp_device(client, admin_pro):
+    client.force_login(admin_pro)  # authenticated, but no verified second factor
+    assert client.get(reverse("admin:index")).status_code == 302
+
+
+@pytest.mark.django_db
+def test_admin_accessible_with_verified_otp_device(verified_admin_client):
+    assert verified_admin_client.get(reverse("admin:index")).status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("model_name", ["user", "pro"])
+def test_admin_never_exposes_credential_fields(verified_admin_client, admin_pro, model_name):
+    admin_pro.issue_login_token()  # populates login_token_hash
+    admin_pro.refresh_from_db()
+    url = reverse(f"admin:techpourtoutes_{model_name}_change", args=[admin_pro.pk])
+    content = verified_admin_client.get(url).content.decode()
+    # Credentials must never appear in the admin — not editable, not even displayed: a
+    # password set here would be stored unhashed
+    assert 'name="password"' not in content
+    assert 'name="login_token_hash"' not in content
+    assert admin_pro.password not in content
+    assert admin_pro.login_token_hash not in content
+
+
+@pytest.mark.django_db
+def test_admin_pro_hides_jobirl_token_and_locks_id(verified_admin_client, admin_pro):
+    admin_pro.jobirl_user_id = 8675309
+    admin_pro.jobirl_user_token = "jobirl-token-do-not-show"
+    admin_pro.save()
+    url = reverse("admin:techpourtoutes_pro_change", args=[admin_pro.pk])
+    content = verified_admin_client.get(url).content.decode()
+    # The Jobirl token is a credential — never exposed.
+    assert 'name="jobirl_user_token"' not in content
+    assert "jobirl-token-do-not-show" not in content
+    # The Jobirl id is set by the API, not by hand — shown read-only (visible, not editable).
+    assert 'name="jobirl_user_id"' not in content
+    assert "8675309" in content

--- a/techpourtoutes/views/coalition_views.py
+++ b/techpourtoutes/views/coalition_views.py
@@ -86,6 +86,10 @@ def workshops_landing(request):
     return render(request, "coalition/workshops_landing.html", {"form": form, "pro": pro})
 
 
+def coalition_welcome(request):
+    return render(request, "coalition/coalition_welcome.html", {})
+
+
 def search_schools(request):
     q = request.GET.get("q", "").strip()
     try:
@@ -111,10 +115,6 @@ def search_schools(request):
         "coalition/partials/school_results.html",
         {"schools": items[:SCHOOL_PAGE_SIZE], "q": q, "page": page, "next_page": next_page},
     )
-
-
-def coalition_welcome(request):
-    return render(request, "coalition/coalition_welcome.html", {})
 
 
 # ------------------- private -------------------

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,7 @@ dependencies = [
     { name = "django-cotton" },
     { name = "django-environ" },
     { name = "django-extensions" },
+    { name = "django-otp" },
     { name = "django-phonenumber-field" },
     { name = "django-simple-history" },
     { name = "django-tailwind-cli" },
@@ -267,6 +268,7 @@ requires-dist = [
     { name = "django-cotton", specifier = ">=2.6.2" },
     { name = "django-environ", specifier = ">=0.13" },
     { name = "django-extensions", specifier = ">=4.1" },
+    { name = "django-otp", specifier = ">=1.7.0" },
     { name = "django-phonenumber-field", specifier = ">=8.4" },
     { name = "django-simple-history", specifier = ">=3.11" },
     { name = "django-tailwind-cli", specifier = ">=4.6" },
@@ -407,6 +409,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b3/ed0f54ed706ec0b54fd251cc0364a249c6cd6c6ec97f04dc34be5e929eac/django_extensions-4.1.tar.gz", hash = "sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb", size = 283078, upload-time = "2025-04-11T01:15:39.617Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/96/d967ca440d6a8e3861120f51985d8e5aec79b9a8bdda16041206adfe7adc/django_extensions-4.1-py3-none-any.whl", hash = "sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336", size = 232980, upload-time = "2025-04-11T01:15:37.701Z" },
+]
+
+[[package]]
+name = "django-otp"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/a3/32b6b53ef1026387375e11236255db7c630d9527a2d33fa6529500a880cd/django_otp-1.7.0.tar.gz", hash = "sha256:961ccf2d80a67303cb46d97427b16c476ee075acfa2b4c82a59d8f1e0745a454", size = 75858, upload-time = "2026-01-07T19:57:17.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f0/75ee6cdcf916b7c67dffa87aecdd173e4d68e456839dd53b9313e9cc9201/django_otp-1.7.0-py3-none-any.whl", hash = "sha256:406d2d7f797dc313569270e06d6c360c7d986c9f653eab80b190d663ed5f1133", size = 71331, upload-time = "2026-01-07T19:57:18.655Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pour sécuriser l'accès à l'admin et éviter d'exposer des données sensibles dans l'admin :

## 2FA sur l'admin (django-otp)
- Ajout de `django-otp` : en production, l'accès à l'admin exige un second facteur TOTP en plus
  du mot de passe (`OTPAdminSite`). Désactivée en local (`DEBUG`) — formulaire de connexion standard.
- Nouvelle commande `manage.py add_totp_device <email>` pour enrôler un appareil (affiche le secret).

## URL de l'admin configurable
- Variable d'environnement `ADMIN_URL` (défaut `admin`) pour déplacer l'admin hors de `/admin/` en production.

## Champs sensibles masqués dans l'admin
- `password` et `login_token_hash` exclus des formulaires admin `User`/`Pro`
  (plus de mot de passe stocké en clair, plus de hash de token modifiable à la main).
- `Pro` : `jobirl_user_token` exclu, `jobirl_user_id` en lecture seule. Pour se connecter à JobIRL, il est nécessaire de faire parvenir le dernier `jobirl_user_token` connu, le modifier à la main est donc dangereux.

Un ratelimiting pour les emails sera ajouté dans une PR séparé (ne concerne pas seulement l'admin)