### PR TITLE
Sécuriser les endpoints de login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,6 @@ CELERY_TASK_ALWAYS_EAGER=True
 CACHE_URL=
 # Limites "<max>/<secondes>" par client (laisser commenté pour garder les défauts)
 # RATELIMIT_LOGIN=5/300
-# RATELIMIT_ENGAGEMENT=10/3600
 
 # Verrouillage du login admin (django-axes) — activé hors DEBUG
 # AXES_FAILURE_LIMIT=5

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,17 @@ N8N_WORKSHOP_WEBHOOK_BASIC_AUTH_PASSWORD=some-password
 REDIS_URL=redis://localhost:6379/0
 CELERY_TASK_ALWAYS_EAGER=True
 
+# Cache & rate limiting des endpoints publics
+# En local, laisser CACHE_URL vide (cache mémoire). En prod, pointer vers un Redis partagé,
+# idéalement une base distincte de Celery (ex. /1). Sur Scalingo : valeur de $SCALINGO_REDIS_URL avec /1.
+CACHE_URL=
+# Limites "<max>/<secondes>" par client (laisser commenté pour garder les défauts)
+# RATELIMIT_LOGIN=5/300
+# RATELIMIT_ENGAGEMENT=10/3600
+
+# Verrouillage du login admin (django-axes) — activé hors DEBUG
+# AXES_FAILURE_LIMIT=5
+
 # Matomo (optionnel — laisser vide pour désactiver le tracking)
 # Valeurs différentes selon l'environnement (staging / prod)
 MATOMO_URL=

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Plateforme web Django pour la communauté TechPourToutes.
 - **Tailwind CSS** + **DaisyUI** (via django-tailwind-cli)
 - **django-cotton** pour les composants UI
 - **django-otp** pour la double authentification (2FA) de l'admin
+- **django-axes** pour le verrouillage du login admin après échecs répétés
 
 ## Structure du projet
 
@@ -120,6 +121,12 @@ L'interface est disponible sur [http://localhost:8025](http://localhost:8025). T
 
 > En production, les emails sont envoyés via [Brevo](https://www.brevo.com/) (Anymail). La variable `BREVO_API_KEY` doit être renseignée dans le `.env`.
 
+## Rate limiting (anti-abus)
+
+L'endpoint POST `login_request` est throttlés **en production** (désactivé en local, `DEBUG=True`) **par email** pour éviter le spam (défaut `5 tentatives/300 secondes`). Au-delà de la limite : réponse `HTTP 429`.
+
+Les compteurs vivent dans le cache Redis : **en production**, définir `CACHE_URL` vers une URL Redis, si possible dans une base logique différente de celle utilisée par Celery si les deux utilisent le même Redis
+
 ## Admin
 
 Par défaut, l'interface d'administration Django est servie sur `/admin/`. En production, l'url est déterminée par la variable d'environnement `ADMIN_URL` (ex. `ADMIN_URL=mon-chemin-prive`).
@@ -133,6 +140,12 @@ uv run python manage.py add_totp_device <email>
 ```
 
 La commande crée un appareil TOTP confirmé et affiche la clé secrète à saisir manuellement dans l'application d'authentification.
+
+### Verrouillage après échecs répétés
+
+En production, [django-axes](https://github.com/jazzband/django-axes) verrouille le login admin après plusieurs échecs de mot de passe (anti-brute-force). Le verrouillage est scopé au couple (identifiant, IP) — personne ne peut donc bloquer un admin de façon globale — et expire automatiquement après `AXES_COOLOFF_TIME` (1 h). Désactivé en local (`DEBUG`).
+
+Variables : `AXES_FAILURE_LIMIT` (défaut 5), `AXES_ENABLED` (défaut : activé hors `DEBUG`). Pour lever un verrou manuellement : `uv run python manage.py axes_reset`.
 
 ## Icônes SVG
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     "anymail",
     "django_otp",
     "django_otp.plugins.otp_totp",
+    "axes",
     # Apps techpourtoutes
     "techpourtoutes",
     "ui",
@@ -63,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "axes.middleware.AxesMiddleware",
 ]
 
 ROOT_URLCONF = "conf.urls"
@@ -199,6 +201,33 @@ COALITION_SPONSOR_RECIPIENTS = env.list(
 CELERY_BROKER_URL = env("REDIS_URL", default="redis://localhost:6379/0")
 CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", default=False)
 CELERY_TASK_EAGER_PROPAGATES = True
+
+# Cache for the rate-limit counters. CACHE_URL should be a Redis instance
+if env("CACHE_URL", default=""):
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": env("CACHE_URL"),
+        }
+    }
+
+# Rate limiting of public POST endpoints, as "<max_requests>/<window_seconds>" per client.
+RATELIMIT_LOGIN = env("RATELIMIT_LOGIN", default="5/300")
+
+# django-axes — locks out repeated failed password logins (admin brute-force protection).
+# Disabled in local dev (DEBUG); the test suite enables it explicitly where needed.
+AUTHENTICATION_BACKENDS = [
+    "axes.backends.AxesStandaloneBackend",  # must come first
+    "django.contrib.auth.backends.ModelBackend",
+]
+AXES_ENABLED = env.bool("AXES_ENABLED", default=not DEBUG)
+AXES_FAILURE_LIMIT = env.int("AXES_FAILURE_LIMIT", default=5)
+AXES_COOLOFF_TIME = 1  # hours before a lock-out expires
+# Scope lock-outs to the (username, IP) pair so nobody can lock a real admin out globally.
+AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
+AXES_RESET_ON_SUCCESS = True
+# Resolve the client IP the same way as the rate limiter (1st X-Forwarded-For entry).
+AXES_CLIENT_IP_CALLABLE = "techpourtoutes.ratelimit.client_ip"
 
 # Matomo analytics (values differ per environment; leave empty to disable tracking)
 MATOMO_URL = env("MATOMO_URL", default="").rstrip("/")

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,16 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def clear_cache(settings):
+    # Force in-memory cache so tests never hit a real server (CACHE_URL may be set in .env);
+    # reset the rate-limit counters between tests so they don't leak across them.
+    settings.CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+    from django.core.cache import cache
+
+    cache.clear()
+
+
+@pytest.fixture(autouse=True)
 def use_simple_static_storage(settings):
     settings.STORAGES = {
         "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "celery>=5.6.3",
   "django>=6.0.4",
   "django-anymail[brevo]>=15",
+  "django-axes>=8.3.1",
   "django-cotton>=2.6.2",
   "django-environ>=0.13",
   "django-extensions>=4.1",

--- a/techpourtoutes/ratelimit.py
+++ b/techpourtoutes/ratelimit.py
@@ -1,0 +1,61 @@
+import functools
+
+from django.conf import settings
+from django.core.cache import cache
+from django.http import HttpResponse
+
+
+def client_ip(request):
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
+def _key_value(request, dimension):
+    if dimension == "ip":
+        return client_ip(request)
+    if dimension == "email":
+        return request.POST.get("email", "").strip().lower()
+    return ""
+
+
+def _parse_rate(rate):
+    max_requests, window = rate.split("/")
+    return int(max_requests), int(window)
+
+
+def rate_limit(setting_name, *, keys=("ip",)):
+    """Throttle POST requests per client IP and/or submitted email.
+
+    `setting_name` points at a settings value of the form "<max>/<seconds>", read at request
+    time so it can be tuned per environment (and overridden in tests). The limit is enforced
+    independently on each dimension in `keys`; a request is blocked (HTTP 429) as soon as one
+    of them exceeds the limit within the window. No-op in local development (DEBUG).
+    """
+
+    def decorator(view):
+        @functools.wraps(view)
+        def wrapper(request, *args, **kwargs):
+            if request.method == "POST" and not settings.DEBUG:
+                max_requests, window = _parse_rate(getattr(settings, setting_name))
+                for dimension in keys:
+                    value = _key_value(request, dimension)
+                    if not value:
+                        continue
+                    cache_key = f"ratelimit:{view.__name__}:{dimension}:{value}"
+                    cache.add(cache_key, 0, window)
+                    try:
+                        count = cache.incr(cache_key)
+                    except ValueError:
+                        cache.set(cache_key, 1, window)
+                        count = 1
+                    if count > max_requests:
+                        return HttpResponse(
+                            "Trop de tentatives. Veuillez réessayer plus tard.", status=429
+                        )
+            return view(request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/techpourtoutes/tests/test_admin_lockout.py
+++ b/techpourtoutes/tests/test_admin_lockout.py
@@ -1,0 +1,26 @@
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+CREDS = {"username": "ghost@example.com", "password": "wrong"}
+
+
+@override_settings(AXES_ENABLED=True, AXES_FAILURE_LIMIT=3)
+@pytest.mark.django_db
+def test_admin_login_locks_out_after_repeated_failures(client):
+    url = reverse("admin:login")
+    for _ in range(3):
+        client.post(url, CREDS, HTTP_X_FORWARDED_FOR="9.9.9.9")
+    blocked = client.post(url, CREDS, HTTP_X_FORWARDED_FOR="9.9.9.9")
+    assert blocked.status_code == 429
+
+
+@override_settings(AXES_ENABLED=True, AXES_FAILURE_LIMIT=3)
+@pytest.mark.django_db
+def test_admin_lockout_is_scoped_per_ip(client):
+    url = reverse("admin:login")
+    for _ in range(3):
+        client.post(url, CREDS, HTTP_X_FORWARDED_FOR="9.9.9.9")
+    assert client.post(url, CREDS, HTTP_X_FORWARDED_FOR="9.9.9.9").status_code == 429
+    # same username from another IP is not locked (no global account lock-out DoS)
+    assert client.post(url, CREDS, HTTP_X_FORWARDED_FOR="8.8.8.8").status_code == 200

--- a/techpourtoutes/tests/test_ratelimit.py
+++ b/techpourtoutes/tests/test_ratelimit.py
@@ -1,0 +1,20 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import override_settings
+from django.urls import reverse
+
+
+@override_settings(RATELIMIT_LOGIN="2/3600")
+@pytest.mark.django_db
+def test_login_request_throttled_per_email_across_ips(client):
+    get_user_model().objects.create_user(username="cible@example.com", email="cible@example.com")
+    url = reverse("login_request")
+    for i in range(2):
+        response = client.post(
+            url, {"email": "cible@example.com"}, HTTP_X_FORWARDED_FOR=f"1.1.1.{i}"
+        )
+        assert response.status_code == 302
+    blocked = client.post(url, {"email": "cible@example.com"}, HTTP_X_FORWARDED_FOR="1.1.1.99")
+    assert blocked.status_code == 429
+    assert len(mail.outbox) == 2  # bombing capped despite varied IPs

--- a/techpourtoutes/views/auth_views.py
+++ b/techpourtoutes/views/auth_views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 
 from ..forms import AccountEditForm, LoginRequestForm
 from ..mailers import LoginMailer
+from ..ratelimit import rate_limit
 from ..services.jobirl_api.refresh_access_token import RefreshAccessToken
 
 
@@ -24,6 +25,7 @@ def _safe_next(request, candidate):
     return ""
 
 
+@rate_limit("RATELIMIT_LOGIN", keys=("email",))
 def login_request(request):
     if request.user.is_authenticated:
         return redirect(reverse("account"))
@@ -78,6 +80,8 @@ def login_verify(request, token):
             target = f"{target}?{urlencode({'next': next_url})}"
         return redirect(target)
 
+    # the following line required because django-axes is configured
+    user.backend = "django.contrib.auth.backends.ModelBackend"
     login(request, user)
     messages.success(request, f"Vous accédez au compte {user.email}. Bienvenue !")
     return redirect(next_url or reverse("account"))

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,7 @@ dependencies = [
     { name = "celery" },
     { name = "django" },
     { name = "django-anymail" },
+    { name = "django-axes" },
     { name = "django-cotton" },
     { name = "django-environ" },
     { name = "django-extensions" },
@@ -265,10 +266,11 @@ requires-dist = [
     { name = "celery", specifier = ">=5.6.3" },
     { name = "django", specifier = ">=6.0.4" },
     { name = "django-anymail", extras = ["brevo"], specifier = ">=15" },
+    { name = "django-axes", specifier = ">=8.3.1" },
     { name = "django-cotton", specifier = ">=2.6.2" },
     { name = "django-environ", specifier = ">=0.13" },
     { name = "django-extensions", specifier = ">=4.1" },
-    { name = "django-otp", specifier = ">=1.7.0" },
+    { name = "django-otp", specifier = ">=1.7" },
     { name = "django-phonenumber-field", specifier = ">=8.4" },
     { name = "django-simple-history", specifier = ">=3.11" },
     { name = "django-tailwind-cli", specifier = ">=4.6" },
@@ -376,6 +378,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/43/f0aadb31f2c58afcd9f001f4291998cbd6d289898167e79d908506fc6faf/django_anymail-15.0.tar.gz", hash = "sha256:23d8ab6589afe8cc1ae7665c26879814ad192f4c3ed837a2a1868b0a056869e0", size = 106985, upload-time = "2026-04-18T20:44:19.237Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/d1/daae99ec3b30886010a499975880ec20c32c622bee6b92c226b715e42f0c/django_anymail-15.0-py3-none-any.whl", hash = "sha256:64d33dd1084bfc8e4e12245f56629be40aa0b0498fc7fc7544d87b9b2048be1e", size = 147229, upload-time = "2026-04-18T20:44:17.323Z" },
+]
+
+[[package]]
+name = "django-axes"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/00c701a22d46288e3eb1340a1c141f5b4002572ce836a3e8d069f1e1de8a/django_axes-8.3.1.tar.gz", hash = "sha256:d57e923c0ba33cf45275253dd1313c3a3ff04bec686b38d677beb2b3d43c7bcd", size = 254715, upload-time = "2026-02-11T20:19:52.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/f6/777a5df7d5698eeb23c7c496cc268c0181f0489dbc5b5f2b235b30e5d8dd/django_axes-8.3.1-py3-none-any.whl", hash = "sha256:f7887582fd12713064f1602091ff6152752becae5e891a15bf802746cab0f51a", size = 74213, upload-time = "2026-02-11T20:19:48.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Rate limiting sur le login

- Décorateur `@rate_limit` générique dans `techpourtoutes/ratelimit.py`, configurable via un setting `<max>/<secondes>`, inactif en `DEBUG`
- Appliqué sur `login_request` par **email uniquement** — pas par IP, pour ne pas bloquer plusieurs utilisateurs sur une même IP publique (entreprise, réseau partagé)
- Compteurs stockés en cache Redis (`CACHE_URL`) ; fallback mémoire en dev
- Seuil par défaut : `RATELIMIT_LOGIN=5/300` (5 tentatives / 5 min)

## Verrouillage admin après tentatives échouées (django-axes)

- Verrouillage après `AXES_FAILURE_LIMIT` échecs (défaut : 5), scopé par couple `(username, IP)` pour éviter tout blocage global d'un compte légitime depuis une IP tierce
- Inactif en `DEBUG`, activable par env (`AXES_ENABLED`)

### Variables d'environnement ajoutées

| Variable | Défaut | Description |
|---|---|---|
| `CACHE_URL` | _(vide)_ | Redis pour les compteurs de rate limit |
| `RATELIMIT_LOGIN` | `5/300` | Seuil login par email |
| `AXES_ENABLED` | `not DEBUG` | Active le verrouillage admin |
| `AXES_FAILURE_LIMIT` | `5` | Tentatives avant verrouillage |
