### PR TITLE
Problème de taille d'icône dans le titre en responsive

### DIFF
--- a/techpourtoutes/templates/coalition/training_ambassador_landing.html
+++ b/techpourtoutes/templates/coalition/training_ambassador_landing.html
@@ -1,5 +1,5 @@
 <c-layout.base>
-    <c-components.title icon-name="devenir-ambassadrice-etudiante-bold" title="Devenir ambassadrice étudiante" />
+    <c-components.title title="Devenir ambassadrice étudiante" />
     <div class="flex flex-wrap gap-2 md:gap-4">
         <c-components.badge label="1 an" />
         <c-components.badge label="En présentiel" />

--- a/ui/templates/cotton/components/title.html
+++ b/ui/templates/cotton/components/title.html
@@ -5,7 +5,7 @@
 {% else %}
     <div class="flex items-center gap-x-3 text-primary-700 {{ class }}">
         {% if icon_name %}
-            <c-components.icon name="{{ icon_name }}" class="size-12" />
+            <c-components.icon name="{{ icon_name }}" class="size-12 shrink-0" />
         {% endif %}
         {% if variant == "h2" %}
             <h2 class="text-xl font-medium leading-[1.2]">{{ title|safe }}</h2>


### PR DESCRIPTION
Dans les titres h1 des pages d'engagement, les icônes à côté du titre pouvaient varier de taille en fonction de l'espace disponible. Je fais en sorte que l'icône garde toujours la même taille.

Pour la page "Devenir ambassadrice étudiante", quels que soient les réglages choisis, la longueur du mot `ambassadrice` posait problème - aussi bien sur mobile que sur des tailles moyennes type tablette. Je supprime donc complètement l'icône pour cette page.