### PR TITLE
fix brevo sync

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,8 @@
       "Bash(ls *)",
       "Bash(pwd)",
       "Read(**/.env.example)",
-      "Read(.env.example)"
+      "Read(.env.example)",
+      "WebFetch(domain:developers.brevo.com)"
     ],
     "deny": [
       "Bash(uv run python manage.py flush *)",

--- a/techpourtoutes/clients/brevo.py
+++ b/techpourtoutes/clients/brevo.py
@@ -2,6 +2,7 @@ from brevo import Brevo
 from brevo.contacts.types.remove_contact_from_list_request_body_ext_ids import (
     RemoveContactFromListRequestBodyExtIds,
 )
+from brevo.core.api_error import ApiError
 from django.conf import settings
 
 
@@ -17,15 +18,26 @@ class BrevoClient:
         self.client = Brevo(api_key=settings.BREVO_API_KEY)
 
     def upsert_contact(self, *, ext_id: str, list_id: int, attributes: dict):
+        """Upsert a contact, recovering from Brevo's SMS-uniqueness conflict.
+
+        Brevo rejects a contact whose SMS is already tied to another contact (HTTP 400).
+        The SMS is optional metadata, so on that error we drop it and retry once; any
+        other error bubbles up unchanged for the service layer to turn into a failure.
+        """
         attributes = dict(attributes)
         email = attributes.pop("EMAIL", None)
-        return self.client.contacts.create_contact(
-            email=email,
-            ext_id=ext_id,
-            list_ids=[list_id],
-            update_enabled=True,
-            attributes=attributes,
-        )
+        try:
+            return self._upsert_contact(
+                email=email, ext_id=ext_id, list_id=list_id, attributes=attributes
+            )
+        except ApiError as exc:
+            message = exc.body.get("message", "") if isinstance(exc.body, dict) else ""
+            if exc.status_code == 400 and "SMS" in message and "already associated" in message:
+                attributes.pop("SMS", None)
+                return self._upsert_contact(
+                    email=email, ext_id=ext_id, list_id=list_id, attributes=attributes
+                )
+            raise
 
     def delete_contact(self, *, ext_id: str):
         return self.client.contacts.delete_contact(ext_id, identifier_type="ext_id")
@@ -37,4 +49,15 @@ class BrevoClient:
         return self.client.contacts.remove_contact_from_list(
             list_id,
             request=RemoveContactFromListRequestBodyExtIds(ext_ids=[ext_id]),
+        )
+
+    # -------------------------- private ----------------------------
+
+    def _upsert_contact(self, *, email, ext_id, list_id, attributes):
+        return self.client.contacts.create_contact(
+            email=email,
+            ext_id=ext_id,
+            list_ids=[list_id],
+            update_enabled=True,
+            attributes=attributes,
         )

--- a/techpourtoutes/services/brevo_api/mappings.py
+++ b/techpourtoutes/services/brevo_api/mappings.py
@@ -4,16 +4,23 @@ from django.apps import apps
 from django.conf import settings
 from phonenumber_field.phonenumber import PhoneNumber
 
+BREVO_MULTIPLE_CHOICE_FIELDS = {"civility", "professional_situation", "engagements"}
+
+BREVO_PRO_CONSTANT_ATTRIBUTES = {
+    "TYPES_DE_CONTACT": ["Coalition TPT"],
+}
+
 FIELD_TO_BREVO_ATTR = {
     "email": "EMAIL",
     "first_name": "PRENOM",
     "last_name": "NOM",
-    "phone": "NUMERO_DE_TEL",
+    "phone": "SMS",
     "civility": "CIVILITE",
-    "job_title": "POSTE",
+    "job_title": "JOB_TITLE",
     "professional_situation": "SITUATION_PRO",
-    "structure_name": "STRUCTURE",
+    "structure_name": "NOM_DE_LA_STRUCTURE",
     "postal_code": "CODE_POSTAL",
+    "engagements": "ENGAGEMENTS",
 }
 
 USER_FIELDS = ["email", "first_name", "last_name"]
@@ -25,12 +32,16 @@ PRO_FIELDS = USER_FIELDS + [
     "professional_situation",
     "structure_name",
     "postal_code",
+    "engagements",
 ]
 
 
 def brevo_attributes_for(instance) -> dict | None:
     if _is_pro(instance):
-        return _attributes_from(instance, PRO_FIELDS)
+        attrs = _attributes_from(instance, PRO_FIELDS)
+        if instance.phone:
+            attrs["TELEPHONE_RAW_NUMBER"] = instance.phone.as_e164.replace("+", "00")
+        return {**attrs, **BREVO_PRO_CONSTANT_ATTRIBUTES}
     return None
 
 
@@ -48,7 +59,20 @@ def _is_pro(instance) -> bool:
 
 
 def _attributes_from(instance, fields: list[str]) -> dict:
-    return {FIELD_TO_BREVO_ATTR[f]: _serialize(getattr(instance, f)) for f in fields}
+    result = {}
+    for field in fields:
+        value = _serialize(getattr(instance, field))
+        if field in BREVO_MULTIPLE_CHOICE_FIELDS:
+            field_meta = instance._meta.get_field(field)
+            choices = dict(getattr(field_meta, "base_field", field_meta).choices)
+            value = [str(choices[v]) for v in (value if isinstance(value, list) else [value])]
+        attribute = FIELD_TO_BREVO_ATTR[field]
+        if isinstance(attribute, list):
+            for attr_name in attribute:
+                result[attr_name] = value
+        else:
+            result[attribute] = value
+    return result
 
 
 def _serialize(value):

--- a/techpourtoutes/tests/test_brevo_client.py
+++ b/techpourtoutes/tests/test_brevo_client.py
@@ -73,6 +73,36 @@ def test_remove_contact_from_list_calls_sdk_with_ext_id_body(mock_brevo_sdk):
 
 
 @override_settings(BREVO_API_KEY="test-key")
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Unable to create contact, SMS is already associated with another Contact",
+        "Unable to update contact, SMS or EXT_ID are already associated with another Contact",
+    ],
+)
+def test_upsert_contact_retries_without_sms_on_sms_conflict(mock_brevo_sdk, message):
+    from brevo.core.api_error import ApiError
+
+    sdk_instance = mock_brevo_sdk.return_value
+    sdk_instance.contacts.create_contact.side_effect = [
+        ApiError(status_code=400, body={"message": message}),
+        None,
+    ]
+
+    BrevoClient().upsert_contact(
+        ext_id="abc-123",
+        list_id=42,
+        attributes={"EMAIL": "x@y.fr", "PRENOM": "X", "SMS": "+33612345678"},
+    )
+
+    assert sdk_instance.contacts.create_contact.call_count == 2
+    second_call_attributes = sdk_instance.contacts.create_contact.call_args_list[1].kwargs[
+        "attributes"
+    ]
+    assert "SMS" not in second_call_attributes
+
+
+@override_settings(BREVO_API_KEY="test-key")
 def test_client_methods_return_sdk_response(mock_brevo_sdk):
     sdk_instance = mock_brevo_sdk.return_value
     sdk_instance.contacts.get_contact_info.return_value = "response"

--- a/techpourtoutes/tests/test_brevo_mappings.py
+++ b/techpourtoutes/tests/test_brevo_mappings.py
@@ -17,12 +17,15 @@ def test_brevo_attributes_for_pro_returns_mapped_attributes(pro):
         "EMAIL": "alice@example.com",
         "PRENOM": "Alice",
         "NOM": "Martin",
-        "NUMERO_DE_TEL": "+33612345678",
-        "CIVILITE": "Madame",
-        "POSTE": "Chercheuse",
-        "SITUATION_PRO": "working",
-        "STRUCTURE": "Inria",
+        "SMS": "+33612345678",
+        "TELEPHONE_RAW_NUMBER": "0033612345678",
+        "CIVILITE": ["Madame"],
+        "JOB_TITLE": "Chercheuse",
+        "SITUATION_PRO": ["En emploi"],
+        "NOM_DE_LA_STRUCTURE": "Inria",
         "CODE_POSTAL": "75001",
+        "ENGAGEMENTS": [],
+        "TYPES_DE_CONTACT": ["Coalition TPT"],
     }
 
 
@@ -48,6 +51,16 @@ def test_brevo_list_id_for_bare_user_returns_none(db):
     user = User.objects.create_user(username="bare@example.com", email="bare@example.com")
 
     assert brevo_list_id_for(user) is None
+
+
+@pytest.mark.django_db
+def test_brevo_attributes_engagements_are_translated_to_labels(pro):
+    from techpourtoutes.models import Pro
+
+    pro.engagements = [Pro.Engagement.MENTOR, Pro.Engagement.WORKSHOPS]
+    pro.save()
+
+    assert brevo_attributes_for(pro)["ENGAGEMENTS"] == ["mentorer", "organiser un atelier"]
 
 
 def test_serialize_phone_returns_e164():


### PR DESCRIPTION
Petits fix pour que la synchro Brevo fonctionne bien : 
- lorsqu'un numéro de téléphone existe déjà pour un autre contact, la création ne doit pas bloquer : nous permettons donc sa création en ne gardant le numéro en mémoire que dans `TELEPHONE_RAW_NUMBER`(et dans un format international correct)
- les champs à choix multiples n'étaient pas persistés : je fix ça
- fix d'un nom de champ Brevo qui n'était pas le bon