### PR TITLE
fix failing test

### DIFF
--- a/techpourtoutes/tests/test_views.py
+++ b/techpourtoutes/tests/test_views.py
@@ -473,6 +473,6 @@ def test_signer_manifeste_post_skips_task_when_sync_disabled(client):
 
 @pytest.mark.django_db
 def test_signer_manifeste_post_invalid_rerenders_with_errors(client):
-    response = client.post(reverse("signer_manifeste"), data=_signature_data(terms_accepted=False))
+    response = client.post(reverse("signer_manifeste"), data=_signature_data(email="not-an-email"))
     assert response.status_code == 200
     assert response.context["form"].errors


### PR DESCRIPTION
J'ai mergé en urgence une PR vendredi pour avoir un formulaire de signature du manifeste en ligne pour Vivatech, il y avait une mini erreur sur un test ; cette PR corrige ce test qui échouait (lié au test, pas au comportement de l'app)