### PR TITLE
Ajout de django-waffle pour les features flags/switches

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     "django_otp",
     "django_otp.plugins.otp_totp",
     "axes",
+    "waffle",
     # Apps techpourtoutes
     "techpourtoutes",
     "ui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "django-phonenumber-field>=8.4",
   "django-simple-history>=3.11",
   "django-tailwind-cli>=4.6",
+  "django-waffle>=5",
   "gunicorn>=25.3",
   "httpx>=0.28.1",
   "ipython>=9.12",

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,7 @@ dependencies = [
     { name = "django-phonenumber-field" },
     { name = "django-simple-history" },
     { name = "django-tailwind-cli" },
+    { name = "django-waffle" },
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "ipython" },
@@ -275,6 +276,7 @@ requires-dist = [
     { name = "django-phonenumber-field", specifier = ">=8.4" },
     { name = "django-simple-history", specifier = ">=3.11" },
     { name = "django-tailwind-cli", specifier = ">=4.6" },
+    { name = "django-waffle", specifier = ">=5.0.0" },
     { name = "gunicorn", specifier = ">=25.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipython", specifier = ">=9.12" },
@@ -292,7 +294,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-django", specifier = ">=4.12" },
     { name = "pytest-httpx", specifier = ">=0.36.2" },
-    { name = "pytest-playwright", specifier = ">=0.8.0" },
+    { name = "pytest-playwright", specifier = ">=0.8" },
     { name = "ruff", specifier = ">=0.15.11" },
 ]
 
@@ -490,6 +492,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/3e/2c22722c02cbae3a1ba65a11b4764418562dd0962f533463dd4b8e2afb0f/django_typer-3.7.1.tar.gz", hash = "sha256:e20720f2f85e30db86be6abd2d5f67e673cfe0bebf7ef4ddd22c37bf8699ea06", size = 2975518, upload-time = "2026-03-31T23:14:15.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/42/eceab8bfc51c43d9dca812fe7922d4eaaa4699a12e3eec3760adc3570e80/django_typer-3.7.1-py3-none-any.whl", hash = "sha256:239518e2ab93b3f5190a79e186589ef2f0c9c4344b6e004b49675ef8755dd4a3", size = 296773, upload-time = "2026-03-31T23:14:12.367Z" },
+]
+
+[[package]]
+name = "django-waffle"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/e1/6f533da0d4ac89f427dfd9410e39bfc14ae3a23335ecd549d76be4b2a834/django_waffle-5.0.0.tar.gz", hash = "sha256:62f9d00eedf68dafb82657beab56e601bddedc1ea1ccfef91d83df8658708509", size = 37761, upload-time = "2025-06-12T07:38:54.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/d2/6f0d664bd35a3fdd0403655c7c32ec290704923f11541ef356b180cd8fbf/django_waffle-5.0.0-py3-none-any.whl", hash = "sha256:3312851d9d926b76b9e90712355781700a383b82b5bf2b61e1f1be97532c0f3d", size = 48137, upload-time = "2025-06-12T07:38:53.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Comment fonctionne django-waffle

django-waffle propose 3 types d'indicateurs, tous stockés en base (visibles/éditables dans le Django admin)

### 1. Switch : un simple booléen global (on/off pour tout le monde), sans logique de ciblage

Pratique pour un kill-switch (notre cas pour l'instant)

### 2. Flag : le plus riche, pour de l'activation conditionnelle par utilisateur

superusers, staff, utilisateurs authentifiés
utilisateurs spécifiques ou groupes spécifiques
pourcentage aléatoire mais stable (via cookie, un même visiteur garde le même état)
une date de rollout automatique
un paramètre GET/cookie de testing pour forcer l'état en dev/QA (pour visiter les deux variantes d'une fonctionnalité en cours de rollout progressif sans avoir besoin de modifier le pourcentage ou d'ajouter son propre compte à la liste des utilisateurs ciblés dans l'admin, si `testing = True`, on peut forcer l'état du flag en ajoutant un paramètre GET à l'URL, sans toucher aux règles de ciblage en base :
```
https://staging.techpourtoutes.io/dashboard?dwft_new_dashboard=1   → force le flag actif
https://staging.techpourtoutes.io/dashboard?dwft_new_dashboard=0   → force le flag inactif
```
Le préfixe dwft_ (= "Django Waffle Test Flag") est configurable via WAFFLE_TEST_COOKIE.

Pour des tests automatisés (Selenium/Playwright), il existe aussi WAFFLE_OVERRIDE (setting global) qui permet de forcer l'état directement via le paramètre GET sans dépendre du cookie, pour éviter les effets de bord entre scénarios de test

### 3. Sample — pourcentage aléatoire mais non stable (recalculé à chaque évaluation, pas de mémorisation par utilisateur). Utile pour de l'A/B testing léger sans notion d'identité.

---

## Utilisation dans le code

```python
from waffle import flag_is_active

def my_view(request):
    if flag_is_active(request, "new_dashboard"):
        ...

from waffle.decorators import waffle_flag

@waffle_flag("new_dashboard")
def my_view(request):
    ...
```

Dans les templates :

```django
{% load waffle_tags %}
{% flag "new_dashboard" %}
  <p>Nouveau tableau de bord</p>
{% else %}
  <p>Ancien tableau de bord</p>
{% endflag %}
```

### Config nécessaire

Gestion via le Django admin ou via `manage.py waffle_flag` / `waffle_switch` / `waffle_sample` (commandes CLI)
En test, Waffle fournit `waffle.testutils.override_flag("name", active=True)` (décorateur ou context manager) pour forcer l'état sans toucher la DB

Toute la doc [est dispo ici](https://waffle.readthedocs.io/en/stable/)