### PR TITLE
Ajout de workflows pour les reviews apps

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,8 @@
       "Bash(pwd)",
       "Read(**/.env.example)",
       "Read(.env.example)",
-      "WebFetch(domain:developers.brevo.com)"
+      "WebFetch(domain:developers.brevo.com)",
+      "WebFetch(domain:doc.scalingo.com)"
     ],
     "deny": [
       "Bash(uv run python manage.py flush *)",

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ ADMIN_URL=admin
 # Désactive l'exigence de 2FA sur l'admin (déjà désactivée si DEBUG=True).
 DISABLE_ADMIN_2FA=False
 
+# `manage.py seed` — activé par défaut si DEBUG=True ; à activer explicitement sur les review apps.
+# SEED_ENABLED=True
+# SEED_ADMIN_EMAIL=admin@techpourtoutes.io
+# SEED_ADMIN_PASSWORD=admin
+
 # Email (Brevo/Anymail — only needed in production; local uses Mailpit on port 1025)
 # Install: brew install mailpit — run with: mailpit — UI at http://localhost:8025
 DEFAULT_FROM_EMAIL=TechPourToutes <bonjour@techpourtoutes.io>

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ FAVICON_NAMEFILE=images/favicon-tpt
 ALLOWED_HOSTS=localhost,127.0.0.1
 DATABASE_URL=postgres://username@localhost:5432/techpourtoutes
 ADMIN_URL=admin
+# Désactive l'exigence de 2FA sur l'admin (déjà désactivée si DEBUG=True).
+DISABLE_ADMIN_2FA=False
 
 # Email (Brevo/Anymail — only needed in production; local uses Mailpit on port 1025)
 # Install: brew install mailpit — run with: mailpit — UI at http://localhost:8025

--- a/.github/actions/install-scalingo-cli/action.yml
+++ b/.github/actions/install-scalingo-cli/action.yml
@@ -1,0 +1,10 @@
+name: "Install Scalingo CLI"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Scalingo CLI (latest)
+      shell: bash
+      run: |
+        wget -qO- https://cli-dl.scalingo.com/install.sh | bash
+        echo "$HOME/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -79,7 +79,8 @@ jobs:
           domain="${URL#https://}"
           domain="${domain#http://}"
           domain="${domain%%/*}"
-          scalingo --app "$REVIEW_APP" env-set "ALLOWED_HOSTS=$domain" "HOST=$URL" "DISABLE_ADMIN_2FA=true"
+          scalingo --app "$REVIEW_APP" env-set \
+            "ALLOWED_HOSTS=$domain" "HOST=$URL" "DISABLE_ADMIN_2FA=true" "SEED_ENABLED=true"
 
       - name: Parse extra env vars from comment
         id: extra-env

--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -1,0 +1,144 @@
+name: "Deploy review app"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  deploy:
+    if: >
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/deploy-review-app') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    environment: review-app
+    concurrency:
+      group: review-app-deploy-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/install-scalingo-cli
+
+      - run: scalingo login --api-token ${{ secrets.SCALINGO_API_TOKEN }}
+
+      - name: Set PR number
+        id: pr
+        run: echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+
+      # `scalingo review-apps` prints a table (App | PR | PR Branch | Created At | Status | URL)
+      # for every review app of the parent. Splitting on "|" survives the box-drawing borders;
+      # trimming handles the padding. It's the only command that reports both deploy status and
+      # URL for a given PR, so it doubles as our "does it exist yet" and "is it ready" check.
+      - name: Create review app and wait for its first deploy
+        id: review-app
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          find_row() {
+            scalingo --app techpourtoutes-staging review-apps | awk -F'|' -v pr="$PR_NUMBER" '
+              { gsub(/^[ \t]+|[ \t]+$/, "", $3) }
+              $3 == pr { gsub(/^[ \t]+|[ \t]+$/, "", $6); gsub(/^[ \t]+|[ \t]+$/, "", $7); print $6 "|" $7 }
+            '
+          }
+
+          row=$(find_row)
+          if [ -z "$row" ]; then
+            echo "Creating review app for PR $PR_NUMBER..."
+            scalingo --app techpourtoutes-staging integration-link-manual-review-app --aware-of-security-risks "$PR_NUMBER"
+          else
+            echo "Review app for PR $PR_NUMBER already exists."
+          fi
+
+          status=""
+          for i in $(seq 1 30); do
+            row=$(find_row)
+            status="${row%%|*}"
+            [ "$status" = "success" ] && break
+            echo "Waiting for review app deploy to finish (status: ${status:-pending})..."
+            sleep 10
+          done
+
+          if [ "$status" != "success" ]; then
+            echo "Timed out waiting for the review app deploy to succeed." >&2
+            exit 1
+          fi
+
+          echo "url=${row#*|}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure review app host
+        env:
+          REVIEW_APP: techpourtoutes-staging-pr${{ steps.pr.outputs.number }}
+          URL: ${{ steps.review-app.outputs.url }}
+        run: |
+          domain="${URL#https://}"
+          domain="${domain#http://}"
+          domain="${domain%%/*}"
+          scalingo --app "$REVIEW_APP" env-set "ALLOWED_HOSTS=$domain" "HOST=$URL" "DISABLE_ADMIN_2FA=true"
+
+      - name: Parse extra env vars from comment
+        id: extra-env
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        with:
+          script: |
+            const body = process.env.COMMENT_BODY || "";
+            const tokens = body.trim().split(/\s+/).slice(1);
+            const setPattern = /^[A-Z_][A-Z0-9_]*=.*$/;
+            const unsetPattern = /^[A-Z_][A-Z0-9_]*-$/;
+            const sets = [];
+            const unsets = [];
+            for (const token of tokens) {
+              if (setPattern.test(token)) {
+                sets.push(token);
+              } else if (unsetPattern.test(token)) {
+                unsets.push(token.slice(0, -1));
+              } else {
+                core.setFailed(`Token invalide dans le commentaire : "${token}". Utilisez KEY=VALUE ou KEY-.`);
+                return;
+              }
+            }
+            core.setOutput("sets", JSON.stringify(sets));
+            core.setOutput("unsets", JSON.stringify(unsets));
+
+      - name: Apply extra env vars
+        env:
+          REVIEW_APP: techpourtoutes-staging-pr${{ steps.pr.outputs.number }}
+          SETS_JSON: ${{ steps.extra-env.outputs.sets }}
+          UNSETS_JSON: ${{ steps.extra-env.outputs.unsets }}
+        run: |
+          echo "$SETS_JSON" | jq -r '.[]' | while IFS= read -r pair; do
+            scalingo --app "$REVIEW_APP" env-set "$pair"
+          done
+          echo "$UNSETS_JSON" | jq -r '.[]' | while IFS= read -r key; do
+            scalingo --app "$REVIEW_APP" env-unset "$key"
+          done
+
+      - name: Seed review app
+        env:
+          REVIEW_APP: techpourtoutes-staging-pr${{ steps.pr.outputs.number }}
+        run: scalingo --app "$REVIEW_APP" run make seed
+
+      - name: Find existing review app comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Review app :"
+
+      - name: Comment PR with review app URL
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          edit-mode: replace
+          body: |
+            Review app :
+            ${{ steps.review-app.outputs.url }}

--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -1,0 +1,36 @@
+name: "Destroy review app"
+
+on:
+  pull_request:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  destroy:
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/destroy-review-app') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ubuntu-latest
+    environment: review-app
+    concurrency:
+      group: review-app-destroy-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/install-scalingo-cli
+
+      - run: scalingo login --api-token ${{ secrets.SCALINGO_API_TOKEN }}
+
+      - name: Destroy review app
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: scalingo --app "techpourtoutes-staging-pr${PR_NUMBER}" destroy --force || true

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -27,6 +27,8 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 SITE_URL = env("HOST", default="https://localhost:8000").rstrip("/")
 # Admin is mounted at this path; override in production to a non-guessable value.
 ADMIN_URL = env("ADMIN_URL", default="admin").strip("/")
+# Escape hatch to disable the admin 2FA requirement outside local dev (e.g. review apps).
+DISABLE_ADMIN_2FA = env.bool("DISABLE_ADMIN_2FA", default=False)
 DATABASES = {
     "default": {
         **env.db("DATABASE_URL"),

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -29,6 +29,12 @@ SITE_URL = env("HOST", default="https://localhost:8000").rstrip("/")
 ADMIN_URL = env("ADMIN_URL", default="admin").strip("/")
 # Escape hatch to disable the admin 2FA requirement outside local dev (e.g. review apps).
 DISABLE_ADMIN_2FA = env.bool("DISABLE_ADMIN_2FA", default=False)
+
+# `manage.py seed` creates an admin account with a well-known-by-default password. Enabled by
+# default in local dev (DEBUG); review apps opt in explicitly since they run with DEBUG=False.
+SEED_ENABLED = env.bool("SEED_ENABLED", default=DEBUG)
+SEED_ADMIN_EMAIL = env("SEED_ADMIN_EMAIL", default="admin@techpourtoutes.io")
+SEED_ADMIN_PASSWORD = env("SEED_ADMIN_PASSWORD", default="admin")
 DATABASES = {
     "default": {
         **env.db("DATABASE_URL"),

--- a/techpourtoutes/admin.py
+++ b/techpourtoutes/admin.py
@@ -7,21 +7,26 @@ from .models import Pro, User
 
 
 class AdminSiteWith2FA(OTPAdminSite):
-    # Require a verified TOTP device (2FA) for admin access, except in local development (DEBUG),
-    # where the stock login form and permissions apply so no second factor is needed. DEBUG is
-    # read per request because admin autodiscover runs before the test runner forces DEBUG=False.
+    # Require a verified TOTP device (2FA) for admin access, except in local development (DEBUG)
+    # or when explicitly disabled (DISABLE_ADMIN_2FA, e.g. review apps), where the stock login
+    # form and permissions apply so no second factor is needed. Settings are read per request
+    # because admin autodiscover runs before the test runner forces DEBUG=False.
     @property
     def login_form(self):
-        return None if settings.DEBUG else OTPAdminSite.login_form
+        return None if self._2fa_disabled() else OTPAdminSite.login_form
 
     @property
     def login_template(self):
-        return None if settings.DEBUG else OTPAdminSite.login_template
+        return None if self._2fa_disabled() else OTPAdminSite.login_template
 
     def has_permission(self, request):
-        if settings.DEBUG:
+        if self._2fa_disabled():
             return AdminSite.has_permission(self, request)
         return super().has_permission(request)
+
+    @staticmethod
+    def _2fa_disabled():
+        return settings.DEBUG or settings.DISABLE_ADMIN_2FA
 
 
 admin.site.__class__ = AdminSiteWith2FA

--- a/techpourtoutes/management/commands/seed.py
+++ b/techpourtoutes/management/commands/seed.py
@@ -3,28 +3,26 @@ from django.core.management.base import BaseCommand, CommandError
 
 from techpourtoutes.models import Pro
 
-ADMIN_EMAIL = "admin@techpourtoutes.io"
-ADMIN_PASSWORD = "admin"
-
 
 class Command(BaseCommand):
     help = "Seed the database with minimal dev data"
 
     def handle(self, *args, **options):
-        if not settings.DEBUG:
+        if not settings.SEED_ENABLED:
             raise CommandError(
-                "seed creates an account with a well-known password and is for local "
-                "development only; it refuses to run with DEBUG=False."
+                "seed creates an account with a well-known-by-default password; it refuses "
+                "to run unless SEED_ENABLED is set."
             )
         self._create_admin_pro()
 
     def _create_admin_pro(self):
-        if Pro.objects.filter(email=ADMIN_EMAIL).exists():
-            self.stdout.write(f"  Admin pro {ADMIN_EMAIL} already exists, skipping.")
+        email = settings.SEED_ADMIN_EMAIL
+        if Pro.objects.filter(email=email).exists():
+            self.stdout.write(f"  Admin pro {email} already exists, skipping.")
             return
         pro = Pro(
-            username=ADMIN_EMAIL,
-            email=ADMIN_EMAIL,
+            username=email,
+            email=email,
             first_name="Admin",
             last_name="TechPourToutes",
             civility=Pro.Civility.MADAME,
@@ -37,8 +35,8 @@ class Command(BaseCommand):
             is_staff=True,
         )
         pro.save()
-        pro.set_password(ADMIN_PASSWORD)
+        pro.set_password(settings.SEED_ADMIN_PASSWORD)
         pro.save(update_fields=["password"])
         self.stdout.write(
-            self.style.SUCCESS(f"  Admin pro created: {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
+            self.style.SUCCESS(f"  Admin pro created: {email} / {settings.SEED_ADMIN_PASSWORD}")
         )

--- a/techpourtoutes/tests/test_admin.py
+++ b/techpourtoutes/tests/test_admin.py
@@ -70,6 +70,13 @@ def test_admin_accessible_with_verified_otp_device(verified_admin_client):
 
 
 @pytest.mark.django_db
+def test_admin_2fa_can_be_disabled_outside_debug(client, admin_pro):
+    client.force_login(admin_pro)  # authenticated, no verified second factor
+    with override_settings(DISABLE_ADMIN_2FA=True):
+        assert client.get(reverse("admin:index")).status_code == 200
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("model_name", ["user", "pro"])
 def test_admin_never_exposes_credential_fields(verified_admin_client, admin_pro, model_name):
     admin_pro.issue_login_token()  # populates login_token_hash

--- a/techpourtoutes/tests/test_seed.py
+++ b/techpourtoutes/tests/test_seed.py
@@ -1,0 +1,35 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
+
+from techpourtoutes.models import Pro
+
+
+@pytest.mark.django_db
+def test_seed_refuses_when_disabled():
+    with override_settings(SEED_ENABLED=False):
+        with pytest.raises(CommandError):
+            call_command("seed")
+
+
+@pytest.mark.django_db
+def test_seed_creates_admin_pro_with_configured_credentials():
+    with override_settings(
+        SEED_ENABLED=True,
+        SEED_ADMIN_EMAIL="reviewer@example.com",
+        SEED_ADMIN_PASSWORD="s3cret-review-pass",
+    ):
+        call_command("seed")
+
+    pro = Pro.objects.get(email="reviewer@example.com")
+    assert pro.check_password("s3cret-review-pass")
+
+
+@pytest.mark.django_db
+def test_seed_is_idempotent():
+    with override_settings(SEED_ENABLED=True):
+        call_command("seed")
+        call_command("seed")
+
+    assert Pro.objects.filter(email="admin@techpourtoutes.io").count() == 1

--- a/ui/static/css/tailwind.css
+++ b/ui/static/css/tailwind.css
@@ -1967,6 +1967,9 @@
   .block {
     display: block;
   }
+  .contents {
+    display: contents;
+  }
   .flex {
     display: flex;
   }


### PR DESCRIPTION
closes #180 

## Contexte

Le déploiement automatique de reviews apps via Scalingo gaspille des ressources en gardant les reviews apps up aussi longtemps que la PR est ouverte (consommation éléctrique + facturation). Le déploiement manuel via l'app Scalingo complexifie le déploiement et la gestion des review apps.

Pour aboutir à une solution plus satisfaisante, cette PR crée des workflows GitHub Actions qui déclenchent la fonctionnalité **"manual review apps"** de Scalingo depuis les PRs

## Commandes
- Pour déployer une review app, il faut poster un commentaire `/deploy-review-app` en étant collaborateur du projet
  - Par défaut, les variables d'env staging sont dupliquées. Si besoin d'ajouter/éditer/retirer des variables d'env sur la review app, ajouter dans le commentaire après `/deploy-review-app`, des tokens séparés par des espaces : `KEY=VALUE` pour définir/mettre à jour une variable, `KEY-` (tiret final) pour la supprimer. 
  
    Exemple : `/deploy-review-app BREVO_SYNC_ENABLED=True SENTRY_DSN-`

    Cela peut servir par exemple pour les features flags ou les sync Brevo. Le développeur qui fait la PR précise dans sa PR si des edits de variables d'env sont nécessaires 
- Pour détruire une review app, il faut poster un commentaire `/destroy-review-app` en étant collaborateur du projet. Si ça n'a pas été fait manuellement, la review app est automatiquement détruire quand la PR est merge.

## À savoir

- un utilisateur admin est créé automatiquement (l'équipe connaît les credentials)